### PR TITLE
add semaphore implementation to stdext

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -35,6 +35,7 @@ Library stdext
     Qring,
     Range,
     Ring,
+    Semaphore,
     Xstringext,
     Threadext,
     Trie,
@@ -47,7 +48,7 @@ Library stdext
     unixext_stubs.c,
     unixext_write_stubs.c,
     zerocheck_stub.c
-  BuildDepends: 
+  BuildDepends:
     threads,
     uuidm,
     unix,

--- a/lib/semaphore.ml
+++ b/lib/semaphore.ml
@@ -1,0 +1,62 @@
+(*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+type semaphore = {
+  mutable n : int;
+  m : Mutex.t;
+  c : Condition.t;
+}
+
+let create n =
+  if n <= 0 then
+    failwith (Printf.sprintf 
+                "Negative semaphore count value (%d) on semaphore creation" n);
+  let m = Mutex.create ()
+  and c = Condition.create () in
+  { n; m; c; }
+
+let acquire s k =
+  if k <= 0 then
+    failwith (Printf.sprintf "Negative weight (%d) on semaphore acquisition" k);
+  Mutex.lock s.m;
+  while s.n < k do
+    Condition.wait s.c s.m;
+  done;
+  if not (s.n >= k) then
+    failwith (Printf.sprintf 
+                "Invalid semaphore count (%d) after acquisition for (%d)" s.n k);
+  s.n <- s.n - k;
+  Condition.signal s.c;
+  Mutex.unlock s.m
+
+let release s k =
+  if k <= 0 then
+    failwith (Printf.sprintf "Negative weight (%d) on semaphore release" k);
+  Mutex.lock s.m;
+  s.n <- s.n + k;
+  Condition.signal s.c;
+  Mutex.unlock s.m
+
+let execute_with_weight s k f =
+  acquire s k;
+  try
+    let x = f () in
+    release s k;
+    x
+  with e ->
+    release s k;
+    raise e
+
+let execute s f =
+  execute_with_weight s 1 f

--- a/lib/semaphore.ml
+++ b/lib/semaphore.ml
@@ -12,7 +12,7 @@
  * GNU Lesser General Public License for more details.
  *)
 
-type semaphore = {
+type t = {
   mutable n : int;
   m : Mutex.t;
   c : Condition.t;
@@ -27,7 +27,8 @@ let create n =
   { n; m; c; }
 
 exception Inconsistent_state of string
-let inconsistent_state string = raise (Inconsistent_state string)
+let inconsistent_state fmt = Printf.kprintf (fun msg ->
+    raise (Inconsistent_state msg)) fmt
 
 let acquire s k =
   if k <= 0 then
@@ -38,9 +39,7 @@ let acquire s k =
     Condition.wait s.c s.m;
   done;
   if not (s.n >= k) then
-    inconsistent_state (
-      Printf.sprintf 
-        "Semaphore value cannot be smaller than %d, got %d" k s.n);
+    inconsistent_state "Semaphore value cannot be smaller than %d, got %d" k s.n;
   s.n <- s.n - k;
   Condition.signal s.c;
   Mutex.unlock s.m

--- a/lib/semaphore.mli
+++ b/lib/semaphore.mli
@@ -1,0 +1,39 @@
+(*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+
+type semaphore
+
+(** [create n] create a semaphore with initial value [n] (a positive integer).
+    Raise an exception if [n] <= 0 *)
+val create : int -> semaphore
+
+(** [acquire k s] block until the semaphore value is >= [k] (a positive integer),
+    then atomically decrement the semaphore value by [k].
+    Raise an exception if [k] <= 0 *)
+val acquire : semaphore -> int -> unit
+
+(** [release k s] atomically increment the semaphore value by [k] (a positive
+    integer).
+    Raise an exception if [k] <= 0 *)
+val release : semaphore -> int -> unit
+
+(** [execute_with_weight s k f] {acquire} the semaphore with [k],
+    then run [f ()], and finally {release} the semaphore with the same value [k]
+    (even in case of failure in the execution of [f]).
+    Return the value of [f ()] or re-raise the exception if any. *)
+val execute_with_weight : semaphore -> int -> (unit -> 'a) -> 'a
+
+(** [execute s f] same as [{execute_with_weight} s 1 f] *)
+val execute : semaphore -> (unit -> 'a) -> 'a

--- a/lib/semaphore.mli
+++ b/lib/semaphore.mli
@@ -13,28 +13,28 @@
  *)
 
 
-type semaphore
+type t
 exception Inconsistent_state of string
 
 (** [create n] create a semaphore with initial value [n] (a positive integer).
     Raise {Invalid_argument} if [n] <= 0 *)
-val create : int -> semaphore
+val create : int -> t
 
 (** [acquire k s] block until the semaphore value is >= [k] (a positive integer),
     then atomically decrement the semaphore value by [k].
     Raise {Invalid_argument} if [k] <= 0 *)
-val acquire : semaphore -> int -> unit
+val acquire : t -> int -> unit
 
 (** [release k s] atomically increment the semaphore value by [k] (a positive
     integer).
     Raise {Invalid_argument} if [k] <= 0 *)
-val release : semaphore -> int -> unit
+val release : t -> int -> unit
 
 (** [execute_with_weight s k f] {acquire} the semaphore with [k],
     then run [f ()], and finally {release} the semaphore with the same value [k]
     (even in case of failure in the execution of [f]).
     Return the value of [f ()] or re-raise the exception if any. *)
-val execute_with_weight : semaphore -> int -> (unit -> 'a) -> 'a
+val execute_with_weight : t -> int -> (unit -> 'a) -> 'a
 
 (** [execute s f] same as [{execute_with_weight} s 1 f] *)
-val execute : semaphore -> (unit -> 'a) -> 'a
+val execute : t -> (unit -> 'a) -> 'a

--- a/lib/semaphore.mli
+++ b/lib/semaphore.mli
@@ -14,19 +14,20 @@
 
 
 type semaphore
+exception Inconsistent_state of string
 
 (** [create n] create a semaphore with initial value [n] (a positive integer).
-    Raise an exception if [n] <= 0 *)
+    Raise {Invalid_argument} if [n] <= 0 *)
 val create : int -> semaphore
 
 (** [acquire k s] block until the semaphore value is >= [k] (a positive integer),
     then atomically decrement the semaphore value by [k].
-    Raise an exception if [k] <= 0 *)
+    Raise {Invalid_argument} if [k] <= 0 *)
 val acquire : semaphore -> int -> unit
 
 (** [release k s] atomically increment the semaphore value by [k] (a positive
     integer).
-    Raise an exception if [k] <= 0 *)
+    Raise {Invalid_argument} if [k] <= 0 *)
 val release : semaphore -> int -> unit
 
 (** [execute_with_weight s k f] {acquire} the semaphore with [k],


### PR DESCRIPTION
The semaphore is used in `xcp-networkd` to limit the number of
concurrent executions of a command (CA-225272).

Signed-off-by: Marcello Seri <marcello.seri@citrix.com>