### PR TITLE
Port to jbuilder: cleanup and fixup PR

### DIFF
--- a/lib/xapi-stdext/stdext.ml
+++ b/lib/xapi-stdext/stdext.ml
@@ -13,6 +13,7 @@ module Opt = Xapi_stdext_monadic.Opt
 (* Standard library extensions and additions*)
 module Pervasiveext = Xapi_stdext_pervasives.Pervasiveext
 module Filenameext = Xapi_stdext_std.Filenameext
+module Hashtblext = Xapi_stdext_std.Hashtblext
 module Listext = Xapi_stdext_std.Listext
 module Xstringext = Xapi_stdext_std.Xstringext
 

--- a/xapi-stdext-threads.opam
+++ b/xapi-stdext-threads.opam
@@ -12,4 +12,5 @@ depends: [
   "jbuilder" {build}
   "base-threads"
   "base-unix"
+  "xapi-stdext-pervasives"
 ]


### PR DESCRIPTION
This PR provides additional fixups and cleanups appeared after new rebuilds after the release of `xapi-stdext 3.0.0`. These have been already included in `xs-opam` as patches and do not require a new release.

A new release will be made once we have ported the libraries dependent on `stdext` to the new structure and the library can be additionally simplified, or earlier if needed for other reasons.