### PR TITLE
 really_write: remove deprecation and make robust against EINTR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
     - TEST=false
     - BASE_REMOTE="https://github.com/xapi-project/xs-opam"
   matrix:
-    - PACKAGE=xapi-stdext OCAML_VERSION=4.04.2 REVDEPS=true \
+    - PACKAGE=xapi-stdext OCAML_VERSION=4.04.2 \
       POST_INSTALL_HOOK="opam install alcotest; env TRAVIS=$TRAVIS TRAVIS_JOB_ID=$TRAVIS_JOB_ID bash -ex coverage.sh"
     - PACKAGE=stdext OCAML_VERSION=4.04.2 REVDEPS=true
     - PACKAGE=xapi-stdext OCAML_VERSION=4.06.0

--- a/lib/xapi-stdext-unix/unixext.ml
+++ b/lib/xapi-stdext-unix/unixext.ml
@@ -465,13 +465,12 @@ amount of data (but not atomically!).
 let rec restart_on_EINTR f x =
   try f x with Unix.Unix_error (Unix.EINTR, _, _) -> restart_on_EINTR f x
 and really_write fd buffer offset len =
-  let n = restart_on_EINTR (Unix.single_write fd buffer offset) len in
+  let n = restart_on_EINTR (Unix.single_write_substring fd buffer offset) len in
   if n < len then really_write fd buffer (offset + n) (len - n);;
 
 (* Ideally, really_write would be implemented with optional arguments ?(off=0) ?(len=String.length string) *)
 let really_write_string fd string =
-  let payload = Bytes.unsafe_of_string string in
-  really_write fd payload 0 (Bytes.length payload)
+  really_write fd string 0 (String.length string)
 
 (* --------------------------------------------------------------------------------------- *)
 (* Functions to read and write to/from a file descriptor with a given latest response time *)

--- a/lib/xapi-stdext-unix/unixext.mli
+++ b/lib/xapi-stdext-unix/unixext.mli
@@ -102,7 +102,7 @@ val really_read_string : Unix.file_descr -> int -> string
  * have been written or an error occurs. This is not atomic but is
  * robust against EINTR errors. 
  * See: https://ocaml.github.io/ocamlunix/ocamlunix.html#sec118 *)
-val really_write : Unix.file_descr -> bytes -> int -> int -> unit
+val really_write : Unix.file_descr -> string -> int -> int -> unit
 val really_write_string : Unix.file_descr -> string -> unit
 val try_read_string : ?limit: int -> Unix.file_descr -> string
 exception Timeout

--- a/lib/xapi-stdext-unix/unixext.mli
+++ b/lib/xapi-stdext-unix/unixext.mli
@@ -99,9 +99,10 @@ val proxy : Unix.file_descr -> Unix.file_descr -> unit
 val really_read : Unix.file_descr -> bytes -> int -> int -> unit
 val really_read_string : Unix.file_descr -> int -> string
 (** [really_write] keeps repeating the write operation until all bytes
- * have been written or an error occurs. This is the same behaviour of
- * [Unix.write] that should be preferred instead. *)
-val really_write : Unix.file_descr -> bytes -> int -> int -> unit [@@ocaml.deprecated]
+ * have been written or an error occurs. This is not atomic but is
+ * robust against EINTR errors. 
+ * See: https://ocaml.github.io/ocamlunix/ocamlunix.html#sec118 *)
+val really_write : Unix.file_descr -> bytes -> int -> int -> unit
 val really_write_string : Unix.file_descr -> string -> unit
 val try_read_string : ?limit: int -> Unix.file_descr -> string
 exception Timeout

--- a/lib/xapi-stdext-unix/unixext_open_stubs.c
+++ b/lib/xapi-stdext-unix/unixext_open_stubs.c
@@ -44,7 +44,10 @@ static int open_flag_table[] = {
 CAMLprim value stub_stdext_unix_open_direct(value path, value flags, value perm)
 {
   CAMLparam3(path, flags, perm);
-  int fd, ret, cv_flags;
+  int fd, cv_flags;
+#ifndef O_DIRECT
+  int ret;
+#endif
   char * p;
 
   cv_flags = convert_flag_list(flags, open_flag_table);
@@ -60,11 +63,13 @@ CAMLprim value stub_stdext_unix_open_direct(value path, value flags, value perm)
 #ifndef O_DIRECT
   if (fd != -1)
     ret = fcntl(fd, F_NOCACHE);
-#endif  
+#endif
   leave_blocking_section();
   stat_free(p);
   if (fd == -1) uerror("open", path);
+#ifndef O_DIRECT
   if (ret == -1) uerror("fcntl", path);
+#endif
 
   CAMLreturn (Val_int(fd));
 }


### PR DESCRIPTION
See discussion in https://ocaml.github.io/ocamlunix/ocamlunix.html#sec118
and xapi-project/xen-api#3570

This also fixed another potential issue in `unixext_open_stubs`