### PR TITLE
CP-28365: improve backtraces by using finally

### DIFF
--- a/lib/xapi-stdext-threads/semaphore.ml
+++ b/lib/xapi-stdext-threads/semaphore.ml
@@ -55,13 +55,8 @@ let release s k =
 
 let execute_with_weight s k f =
   acquire s k;
-  try
-    let x = f () in
-    release s k;
-    x
-  with e ->
-    release s k;
-    raise e
+  Xapi_stdext_pervasives.Pervasiveext.finally f
+    (fun () -> release s k)
 
 let execute s f =
   execute_with_weight s 1 f

--- a/lib/xapi-stdext-threads/threadext.ml
+++ b/lib/xapi-stdext-threads/threadext.ml
@@ -18,7 +18,13 @@ module Mutex = struct
   (** execute the function f with the mutex hold *)
   let execute lock f =
     Mutex.lock lock;
-    let r = begin try f () with exn -> Mutex.unlock lock; raise exn end; in
+    let r =
+      try f ()
+      with exn ->
+        Backtrace.is_important exn;
+        Mutex.unlock lock;
+        raise exn
+    in
     Mutex.unlock lock;
     r
 end

--- a/lib/xapi-stdext-threads/threadext.ml
+++ b/lib/xapi-stdext-threads/threadext.ml
@@ -18,15 +18,7 @@ module Mutex = struct
   (** execute the function f with the mutex hold *)
   let execute lock f =
     Mutex.lock lock;
-    let r =
-      try f ()
-      with exn ->
-        Backtrace.is_important exn;
-        Mutex.unlock lock;
-        raise exn
-    in
-    Mutex.unlock lock;
-    r
+    Xapi_stdext_pervasives.Pervasiveext.finally f (fun () -> Mutex.unlock lock)
 end
 
 

--- a/lib/xapi-stdext-unix/unixext.ml
+++ b/lib/xapi-stdext-unix/unixext.ml
@@ -148,12 +148,9 @@ let fd_blocks_fold block_size f start fd =
 
 let with_directory dir f =
   let dh = Unix.opendir dir in
-  let r =
-    try f dh
-    with exn -> Unix.closedir dh; raise exn
-  in
-  Unix.closedir dh;
-  r
+  Xapi_stdext_pervasives.Pervasiveext.finally
+    (fun () -> f dh)
+    (fun () -> Unix.closedir dh)
 
 let buffer_of_fd fd = 
   fd_blocks_fold 1024 (fun b s -> Buffer.add_bytes b s; b) (Buffer.create 1024) fd

--- a/lib/xapi-stdext-unix/unixext.ml
+++ b/lib/xapi-stdext-unix/unixext.ml
@@ -254,6 +254,7 @@ let open_connection_fd host port =
       connect s ai.ai_addr;
       s
     with e ->
+      Backtrace.is_important e;
       close s;
       raise e
 
@@ -263,7 +264,10 @@ let open_connection_unix_fd filename =
     let addr = Unix.ADDR_UNIX(filename) in
     Unix.connect s addr;
     s
-  with e -> Unix.close s; raise e
+  with e ->
+    Backtrace.is_important e;
+    Unix.close s;
+    raise e
 
 module CBuf = struct
   (** A circular buffer constructed from a string *)


### PR DESCRIPTION
Stacktraces were lost in functions wrapped with `Mutex.execute`:
```
Raised at file \"lib/xapi-stdext-pervas
ives/pervasiveext.ml\", line 26, characters 6-15\nCalled from file \"lib/xapi-stdext-threads/threadext.ml\", line 21, characters 22-26\nRe-raised at file \"lib/xapi-stdext-threads/thre
adext.ml\", line 21, characters 58-67\nCalled from file \"lib/debug.ml\", line 287, characters 8-12\n
```

The `Pervasiveext.finally` function already does the right thing and calls `Backtrace.is_important exn` to not loose the stacktrace, so update all the handcoded finally functions to use our own finally.