### PR TITLE
CA-292641: Use Logs to log cleanup exn instead of shadowing the origi…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,14 +9,14 @@ script: bash -ex ./.travis-docker.sh
 env:
   global:
     - PINS="stdext:. xapi-stdext:. xapi-stdext-base64:. xapi-stdext-bigbuffer:. xapi-stdext-date:. xapi-stdext-deprecated:. xapi-stdext-encodings:. xapi-stdext-monadic:. xapi-stdext-pervasives:. xapi-stdext-range:. xapi-stdext-std:. xapi-stdext-threads:. xapi-stdext-unix:. xapi-stdext-zerocheck:."
+    - OCAML_VERSION=4.06.0
     - DISTRO="ubuntu-16.04"
     - TEST=false
     - BASE_REMOTE="https://github.com/xapi-project/xs-opam"
   matrix:
-    - PACKAGE=xapi-stdext OCAML_VERSION=4.04.2 \
+    - PACKAGE=xapi-stdext \
       POST_INSTALL_HOOK="opam install alcotest; env TRAVIS=$TRAVIS TRAVIS_JOB_ID=$TRAVIS_JOB_ID bash -ex coverage.sh"
-    - PACKAGE=stdext OCAML_VERSION=4.04.2 REVDEPS=true
-    - PACKAGE=xapi-stdext OCAML_VERSION=4.06.0
+    - PACKAGE=stdext REVDEPS=true
 matrix:
   fast_finish: true
   allow_failures:

--- a/lib/xapi-stdext-pervasives/jbuild
+++ b/lib/xapi-stdext-pervasives/jbuild
@@ -3,5 +3,7 @@
 (library
   ((name xapi_stdext_pervasives)
    (public_name xapi-stdext-pervasives)
-   (libraries (xapi-backtrace))
+   (libraries
+     (logs
+      xapi-backtrace))
    ))

--- a/xapi-stdext-pervasives.opam
+++ b/xapi-stdext-pervasives.opam
@@ -10,5 +10,6 @@ build:  [[ "jbuilder" "build" "-p" name "-j" jobs ]]
 
 depends: [
   "jbuilder" {build}
+  "logs"
   "xapi-backtrace"
 ]


### PR DESCRIPTION
…nal one with it

Use the Logs library to report the cleanup exception we caught. This
way, we don't have to depend on xcp-idl. In xcp-idl, a Logs reporter
will be registered, which collects the log messages from Logs and
reports them in the usual way.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>