### PR TITLE
CA-310525 fix C binding for statvfs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,12 @@
 language: c
-sudo: false
-services:
-  - docker
-install:
-  - wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-docker.sh
-  - wget https://raw.githubusercontent.com/xapi-project/xapi-travis-scripts/master/coverage.sh
-script: bash -ex ./.travis-docker.sh
+sudo: required
+service: docker
+install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-docker.sh
+script: bash -ex .travis-docker.sh
 env:
   global:
+    - PACKAGE="xapi-stdext"
     - PINS="stdext:. xapi-stdext:. xapi-stdext-base64:. xapi-stdext-bigbuffer:. xapi-stdext-date:. xapi-stdext-deprecated:. xapi-stdext-encodings:. xapi-stdext-monadic:. xapi-stdext-pervasives:. xapi-stdext-range:. xapi-stdext-std:. xapi-stdext-threads:. xapi-stdext-unix:. xapi-stdext-zerocheck:."
-    - OCAML_VERSION=4.07
-    - DISTRO="ubuntu-16.04"
-    - TEST=false
-    - BASE_REMOTE="https://github.com/xapi-project/xs-opam"
+    - BASE_REMOTE="https://github.com/xapi-project/xs-opam.git"
   matrix:
-    - PACKAGE=xapi-stdext \
-      POST_INSTALL_HOOK="opam install alcotest; env TRAVIS=$TRAVIS TRAVIS_JOB_ID=$TRAVIS_JOB_ID bash -ex coverage.sh"
-    - PACKAGE=stdext REVDEPS=true
-matrix:
-  fast_finish: true
-  allow_failures:
-    - env: PACKAGE=xapi-stdext OCAML_VERSION=4.07
+    - DISTRO="debian-9-ocaml-4.07"

--- a/lib/xapi-stdext-unix/unixext_stubs.c
+++ b/lib/xapi-stdext-unix/unixext_stubs.c
@@ -315,36 +315,26 @@ CAMLprim value stub_fdset_is_empty(value set)
 CAMLprim value stub_statvfs(value filename) 
 {
   CAMLparam1(filename);
-  CAMLlocal2(v,tmp);
+  CAMLlocal1(v);
   int ret;
-  int i;
   struct statvfs buf;
 
   ret = statvfs(String_val(filename), &buf);
 
   if(ret == -1) uerror("statvfs", Nothing);
 
-  tmp=caml_copy_int64(0);
-
-  /* Allocate the thing to return and ensure each of the
-	 fields is set to something valid before attempting 
-	 any further allocations */
-  v=alloc_small(11,0);
-  for(i=0; i<11; i++) {
-	Field(v,i)=tmp;
-  }
-
-  Field(v,0)=caml_copy_int64(buf.f_bsize);
-  Field(v,1)=caml_copy_int64(buf.f_frsize);
-  Field(v,2)=caml_copy_int64(buf.f_blocks);
-  Field(v,3)=caml_copy_int64(buf.f_bfree);
-  Field(v,4)=caml_copy_int64(buf.f_bavail);
-  Field(v,5)=caml_copy_int64(buf.f_files);
-  Field(v,6)=caml_copy_int64(buf.f_ffree);
-  Field(v,7)=caml_copy_int64(buf.f_favail);
-  Field(v,8)=caml_copy_int64(buf.f_fsid);
-  Field(v,9)=caml_copy_int64(buf.f_flag);
-  Field(v,10)=caml_copy_int64(buf.f_namemax);
+  v=caml_alloc(11,0);
+  Store_field(v, 0, caml_copy_int64(buf.f_bsize));
+  Store_field(v, 1, caml_copy_int64(buf.f_frsize));
+  Store_field(v, 2, caml_copy_int64(buf.f_blocks));
+  Store_field(v, 3, caml_copy_int64(buf.f_bfree));
+  Store_field(v, 4, caml_copy_int64(buf.f_bavail));
+  Store_field(v, 5, caml_copy_int64(buf.f_files));
+  Store_field(v, 6, caml_copy_int64(buf.f_ffree));
+  Store_field(v, 7, caml_copy_int64(buf.f_favail));
+  Store_field(v, 8, caml_copy_int64(buf.f_fsid));
+  Store_field(v, 9, caml_copy_int64(buf.f_flag));
+  Store_field(v,10, caml_copy_int64(buf.f_namemax));
 
   CAMLreturn(v);
 }


### PR DESCRIPTION
We rarely see statvfs return 0 for bfree and suspect that this is a GC
related problem. The existing implementation violates rule 6 in the
OCaml manual

  https://caml.inria.fr/pub/docs/manual-ocaml/intfc.html#sec442

which mandates to use caml_modify when updating a field with an existing
value. This commit handles this by using Store_field. See also the
discussion at

  https://discuss.ocaml.org/t/finding-gc-problems-in-c-bindings/3453/2

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>