### PR TITLE
CA-338243 iso8601.to_string backwards compatibility

### DIFF
--- a/lib/xapi-stdext-date/date.ml
+++ b/lib/xapi-stdext-date/date.ml
@@ -50,8 +50,8 @@ type iso8601 =
 
 let to_string = function
   | Legacy x -> x
-  | UTC t    -> Ptime.to_rfc3339 ~tz_offset_s:0 (* to ensure Z printed, rather than +00:00 *)
-                                 t
+  | UTC t    -> Ptime.to_rfc3339 ~tz_offset_s:0 (* to ensure Z printed, rather than +00:00 *) t |>
+                Astring.String.filter (fun char -> char <> '-')
 
 let of_float x =
   let time = Unix.gmtime x in

--- a/lib/xapi-stdext-date/dune
+++ b/lib/xapi-stdext-date/dune
@@ -1,6 +1,7 @@
 (library
   (name xapi_stdext_date)
   (public_name xapi-stdext-date)
-  (libraries unix
-             ptime)
+  (libraries astring
+             ptime
+             unix)
 )

--- a/lib_test/test_encodings.ml
+++ b/lib_test/test_encodings.ml
@@ -522,6 +522,8 @@ module Date = struct
   let check_float_neq = Alcotest.(check @@ neg @@ float 1e-2)
   let check_string = Alcotest.(check string)
   let check_true str = Alcotest.(check bool) str true
+  let dash_time_str = "2020-04-07T08:28:32Z"
+  let no_dash_time_str = "20200407T08:28:32Z"
 
   let iso8601_tests =
     let test_of_float_invertible () =
@@ -530,11 +532,6 @@ module Date = struct
       check_float "to_float inverts of_float" time (time |> of_float |> to_float);
       check_true "of_float inverts to_float" @@ eq (time |> of_float) (time |> of_float |> to_float |> of_float);
       check_float_neq "non-integers don't work" non_int_time (non_int_time |> of_float |> to_float)
-    in
-
-    let test_of_string_invertible time () =
-      check_string "to_string inverts of_string" time (time |> of_string |> to_string);
-      check_true "of_string inverts to_string" (eq (time |> of_string) (time |> of_string |> to_string |> of_string));
     in
 
     let test_only_utc () =
@@ -546,18 +543,26 @@ module Date = struct
     in
 
     let test_ca333908 () =
-      let dash_time_str = "2020-04-07T08:28:32Z" in
-      let no_dash_time_str = "20200407T08:28:32Z" in
-      test_of_string_invertible dash_time_str ();
-      test_of_string_invertible no_dash_time_str ();
       check_float "dash time and no dash time have same float repr"
                   (dash_time_str |> of_string |> to_float)
                   (no_dash_time_str |> of_string |> to_float)
     in
 
+    let test_of_string_invertible_when_no_dashes () =
+      check_string "to_string inverts of_string" no_dash_time_str (no_dash_time_str |> of_string |> to_string);
+      check_true "of_string inverts to_string" (eq (no_dash_time_str |> of_string) (no_dash_time_str |> of_string |> to_string |> of_string));
+    in
+
+    (* CA-338243 - breaking backwards compatibility will break XC and XRT *)
+    let test_to_string_backwards_compatibility () =
+      check_string "to_string is backwards compatible" no_dash_time_str (dash_time_str |> of_string |> to_string);
+    in
+
     [ "test_of_float_invertible", `Quick, test_of_float_invertible
     ; "test_only_utc", `Quick, test_only_utc
     ; "test_ca333908", `Quick, test_ca333908
+    ; "test_of_string_invertible_when_no_dashes", `Quick, test_of_string_invertible_when_no_dashes
+    ; "test_to_string_backwards_compatibility", `Quick, test_to_string_backwards_compatibility
     ]
 
   let tests = iso8601_tests

--- a/xapi-stdext-date.opam
+++ b/xapi-stdext-date.opam
@@ -11,6 +11,7 @@ build:  [[ "dune" "build" "-p" name "-j" jobs ]]
 depends: [
   "ocaml"
   "dune" {build}
+  "astring"
   "base-unix"
   "ptime"
 ]


### PR DESCRIPTION
cb5f60dfc136dadd9a28d30a146f75288566a757 meant that any datetimes which
are parsable by ptime would be emitted containing dashes, but clients
have previously expected datetimes coming from the toolstack to be in
the form YYYYMMDDTHH:mm:ssZ. We fix this by removing dashes when
converting a ptime datetime to a string.