### PR TITLE
CA-338243 remove legacy variant in iso8601

### DIFF
--- a/lib/xapi-stdext-date/date.ml
+++ b/lib/xapi-stdext-date/date.ml
@@ -30,28 +30,26 @@ let rfc822_to_string x = x
 
 (* ==== ISO8601/RFC3339 ==== *)
 
-(** the name doesn't make much sense anymore, but is kept for compatibility reasons *)
-type iso8601 =
-  | UTC of Ptime.t   (* rfc3339 - accepts only the date in YYYY-MM-DD format *)
-  | Legacy of string (* iso8601 - accepts both YYYYMMDD & YYYY-MM-DD *)
+type iso8601 = Ptime.t
 
  let of_string x =
-  (** prefer to parse with ptime, but rfc3339 does not accept YYYYMMDD)
-    * we fallback on legacy parsing to accept iso8601 datetimes *)
+  let x =
+    try
+      (* if x doesn't contain dashes, insert them, so that ptime can parse x *)
+      Scanf.sscanf x "%04d%02d%02dT%s" (fun y mon d rest ->
+        Printf.sprintf "%04d-%02d-%02dT%s" y mon d rest
+      )
+    with _ -> x
+  in
   match x |> Ptime.of_rfc3339 |> Ptime.rfc3339_error_to_msg with
-  | Error _       -> let assert_utc x =
-                       try Scanf.sscanf x "%_[0-9]T%_[0-9]:%_[0-9]:%_[0-9]Z" ()
-                       with _ -> invalid_arg (Printf.sprintf "date.ml:of_string: %s" x)
-                     in
-                     assert_utc x; Legacy x
-  | Ok (t, tz, _) -> match tz with
-                     | None | Some 0 -> UTC t
-                     | Some _        -> invalid_arg (Printf.sprintf "date.ml:of_string: %s" x)
+  | Error (`Msg e) -> invalid_arg (Printf.sprintf "date.ml:of_string: %s" e)
+  | Ok (t, tz, _)  -> match tz with
+                      | None | Some 0 -> t
+                      | Some _        -> invalid_arg (Printf.sprintf "date.ml:of_string: %s" x)
 
-let to_string = function
-  | Legacy x -> x
-  | UTC t    -> Ptime.to_rfc3339 ~tz_offset_s:0 (* to ensure Z printed, rather than +00:00 *) t |>
-                Astring.String.filter (fun char -> char <> '-')
+let to_string t =
+  Ptime.to_rfc3339 ~tz_offset_s:0 (* to ensure Z printed, rather than +00:00 *) t |>
+  Astring.String.filter (fun char -> char <> '-') (* remove dashes for backwards compatibility *)
 
 let of_float x =
   let time = Unix.gmtime x in
@@ -76,16 +74,8 @@ let to_float_localtime x =
                        tm_wday = 0; tm_yday = 0; tm_isdst = true;
                      })
   in
-  match x with
-  | UTC t    ->
-    let ((y, mon, d), ((h, min, s), _)) = Ptime.to_date_time t in
-    datetime_to_float y mon d h min s
-  | Legacy x ->
-      try
-        Scanf.sscanf x "%04d%02d%02dT%02d:%02d:%02d" (fun y mon d h min s ->
-          datetime_to_float y mon d h min s
-        )
-      with e -> invalid_arg (Printf.sprintf "date.ml:to_float_localtime: %s" x)
+  let ((y, mon, d), ((h, min, s), _)) = Ptime.to_date_time x in
+  datetime_to_float y mon d h min s
 
 (* Convert tm in UTC back into calendar time x (using offset between above
    UTC and localtime fns to determine offset between UTC and localtime, then
@@ -100,7 +90,4 @@ let assert_utc _ = ()
 
 let never = of_float 0.0
 
-let eq x y = match x, y with
-  | Legacy _, UTC _ | UTC _, Legacy _ -> false
-  | UTC x, UTC y                      -> x = y
-  | Legacy x, Legacy y                -> x = y
+let eq = Ptime.equal


### PR DESCRIPTION
We can use ptime to parse any legacy dates by removing
any dashes before passing to ptime.
