### PR TITLE
CP-33121: run encodings tests as part of the encodings package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,7 @@ install:
 script: bash -ex .travis-docker.sh
 env:
   global:
-    - PACKAGE="xapi-stdext"
-    - PINS="stdext:. xapi-stdext:. xapi-stdext-date:. xapi-stdext-encodings:. xapi-stdext-pervasives:. xapi-stdext-std:. xapi-stdext-threads:. xapi-stdext-unix:. xapi-stdext-zerocheck:."
+    - PINS="stdext:. xapi-stdext-date:. xapi-stdext-encodings:. xapi-stdext-pervasives:. xapi-stdext-std:. xapi-stdext-threads:. xapi-stdext-unix:. xapi-stdext-zerocheck:."
+  jobs:
+    - PACKAGE="stdext"
+    - PACKAGE="xapi-stdext-encodings"

--- a/lib_test/dune
+++ b/lib_test/dune
@@ -1,13 +1,8 @@
-(executable
-  (name suite)
+(test
+  (name test_encodings)
+  (package xapi-stdext-encodings)
   (libraries
     alcotest
     xapi_stdext_encodings
-    xapi_stdext_date)
-)
-
-(alias
-  (name runtest)
-  (deps (:x suite.exe))
-  (action (run %{x}))
+    xapi-stdext-date)
 )

--- a/lib_test/suite.ml
+++ b/lib_test/suite.ml
@@ -1,5 +1,0 @@
-
-let () =
-  Alcotest.run
-    "suite"
-    [ "Test_encodings", Test_encodings.tests ]

--- a/lib_test/test_encodings.ml
+++ b/lib_test/test_encodings.ml
@@ -575,3 +575,7 @@ let tests =
       XML_UTF8_UCS_validator.tests @
       UTF8_codec            .tests @
       Date                  .tests
+let () =
+  Alcotest.run
+    "suite"
+    [ "Test_encodings", tests ]

--- a/stdext.opam
+++ b/stdext.opam
@@ -12,10 +12,8 @@ depends: [
   "ocaml"
   "dune" {build}
   "xapi-stdext-date"
-  "xapi-stdext-deprecated"
   "xapi-stdext-encodings"
   "xapi-stdext-pervasives"
-  "xapi-stdext-range"
   "xapi-stdext-std"
   "xapi-stdext-threads"
   "xapi-stdext-unix"

--- a/xapi-stdext-encodings.opam
+++ b/xapi-stdext-encodings.opam
@@ -6,11 +6,16 @@ dev-repo: "git://github.com/xapi-project/stdext.git"
 homepage: "https://xapi-project.github.io/"
 tags: [ "org:xapi-project" ]
 
-build:  [[ "dune" "build" "-p" name "-j" jobs ]]
+build:  [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
 
 depends: [
   "ocaml"
   "dune" {build}
+  "alcotest" {with-test}
+  "xapi-stdext-date" {with-test}
 ]
 synopsis: "A deprecated collection of utility functions - Encodings module"
 description: """


### PR DESCRIPTION
It's the only library that currently has tests

xapi-stdext is ignored in travis now, nothing else is using it and it
can ber dropped from now on.

Signed-off-by: Pau Ruiz Safont <pau.safont@citrix.com>