### PR TITLE
CA-342171 allow clients to create an iso8601 from localtime

### DIFF
--- a/lib/xapi-stdext-date/date.ml
+++ b/lib/xapi-stdext-date/date.ml
@@ -30,9 +30,14 @@ let rfc822_to_string x = x
 
 (* ==== ISO8601/RFC3339 ==== *)
 
-type iso8601 = Ptime.t
+type print_type = PrintLocal | PrintUTC
+(* we must store the print_type with iso8601 to handle the case where the local time zone is UTC *)
+type iso8601 = Ptime.date * Ptime.time * print_type
 
- let of_string x =
+let of_dt print_type dt = let (date, time) = dt in (date, time, print_type)
+let to_dt (date, time, _) = (date, time)
+
+let of_string x =
   let x =
     try
       (* if x doesn't contain dashes, insert them, so that ptime can parse x *)
@@ -44,50 +49,56 @@ type iso8601 = Ptime.t
   match x |> Ptime.of_rfc3339 |> Ptime.rfc3339_error_to_msg with
   | Error (`Msg e) -> invalid_arg (Printf.sprintf "date.ml:of_string: %s" e)
   | Ok (t, tz, _)  -> match tz with
-                      | None | Some 0 -> t
+                      | None | Some 0 -> Ptime.to_date_time t |> of_dt PrintUTC
                       | Some _        -> invalid_arg (Printf.sprintf "date.ml:of_string: %s" x)
 
-let to_string t =
-  Ptime.to_rfc3339 ~tz_offset_s:0 (* to ensure Z printed, rather than +00:00 *) t |>
-  Astring.String.filter (fun char -> char <> '-') (* remove dashes for backwards compatibility *)
+let to_string ((y,mon,d), ((h,min,s), _), print_type) =
+  match print_type with
+  | PrintUTC   -> Printf.sprintf "%04i%02i%02iT%02i:%02i:%02iZ" y mon d h min s
+  | PrintLocal -> Printf.sprintf "%04i%02i%02iT%02i:%02i:%02i" y mon d h min s
 
-let of_float x =
-  let time = Unix.gmtime x in
-  Printf.sprintf "%04d-%02d-%02dT%02d:%02d:%02dZ"
-    (time.Unix.tm_year+1900)
-    (time.Unix.tm_mon+1)
-    time.Unix.tm_mday
-    time.Unix.tm_hour
-    time.Unix.tm_min
-    time.Unix.tm_sec |> of_string
+let to_ptime_t t =
+  match to_dt t |> Ptime.of_date_time with
+  | Some t -> t
+  | None ->
+    let (_, (_, offset), _) = t in
+    invalid_arg (Printf.sprintf "date.ml:to_t: dt='%s', offset='%i' is invalid" (to_string t) offset)
 
-(* Convert tm in localtime to calendar time, x *)
-let to_float_localtime x =
-  let datetime_to_float y mon d h min s =
-    fst Unix.(mktime { tm_year = y - 1900;
-                       tm_mon = mon - 1;
-                       tm_mday = d;
-                       tm_hour = h;
-                       tm_min = min;
-                       tm_sec = s;
-                       (* These are ignored: *)
-                       tm_wday = 0; tm_yday = 0; tm_isdst = true;
-                     })
-  in
-  let ((y, mon, d), ((h, min, s), _)) = Ptime.to_date_time x in
-  datetime_to_float y mon d h min s
+let of_float s =
+  match Ptime.of_float_s s with
+  | None -> invalid_arg (Printf.sprintf "date.ml:of_float: %f" s)
+  | Some t -> Ptime.to_date_time t |> of_dt PrintUTC
 
 (* Convert tm in UTC back into calendar time x (using offset between above
    UTC and localtime fns to determine offset between UTC and localtime, then
    correcting for this)
 *)
-let to_float x =
-  let t = Unix.time () in
-  let offset = (t |> of_float |> to_float_localtime) -. t in
-  to_float_localtime x -. offset
+let to_float t =
+  let (_, _, print_type) = t in
+  match print_type with
+  | PrintLocal -> invalid_arg "date.ml:to_float: expected utc"
+  | PrintUTC   -> to_ptime_t t |> Ptime.to_float_s
+
+let _localtime current_tz_offset t =
+  let tz_offset_s = current_tz_offset |> Option.value ~default:0 in
+  let localtime = t |> Ptime.to_date_time ~tz_offset_s |> of_dt PrintLocal in
+  let (_, (_, localtime_offset), _) = localtime in
+  if localtime_offset <> tz_offset_s then
+    invalid_arg (
+      Printf.sprintf "date.ml:_localtime: offsets don't match. offset='%i', t='%s'"
+        tz_offset_s
+        (Ptime.to_rfc3339 t)
+    );
+  localtime
+
+let _localtime_string current_tz_offset t =
+  _localtime current_tz_offset t |> to_string
+
+let localtime () =
+  _localtime (Ptime_clock.current_tz_offset_s ()) (Ptime_clock.now ())
 
 let assert_utc _ = ()
 
 let never = of_float 0.0
 
-let eq = Ptime.equal
+let eq x y = x = y

--- a/lib/xapi-stdext-date/date.mli
+++ b/lib/xapi-stdext-date/date.mli
@@ -28,7 +28,7 @@ val to_float : iso8601 -> float
 val to_string : iso8601 -> string
 
 (** Convert ISO 8601 formatted string to a date/time value.
-  * Does not accept a timezone annotated datetime *)
+  * Does not accept a timezone annotated datetime - i.e. string must be UTC, and end with a Z *)
 val of_string : string -> iso8601
 
 (** Raises an Invalid_argument exception if the given date is not a UTC date.
@@ -38,6 +38,11 @@ val assert_utc : iso8601 -> unit
 
 (** Representation of the concept "never" (actually 00:00:00 UTC, 1 Jan 1970). *)
 val never: iso8601
+
+(** exposed for testing *)
+val _localtime_string : Ptime.tz_offset_s option -> Ptime.t -> string
+
+val localtime : unit -> iso8601
 
 (** {2 RFC 822 Dates} *)
 

--- a/lib/xapi-stdext-date/dune
+++ b/lib/xapi-stdext-date/dune
@@ -3,5 +3,6 @@
   (public_name xapi-stdext-date)
   (libraries astring
              ptime
+             ptime.clock.os
              unix)
 )

--- a/lib_test/test_encodings.ml
+++ b/lib_test/test_encodings.ml
@@ -522,7 +522,7 @@ module Date = struct
   let check_string = Alcotest.(check string)
   let check_true str = Alcotest.(check bool) str true
   let dash_time_str = "2020-04-07T08:28:32Z"
-  let no_dash_time_str = "20200407T08:28:32Z"
+  let no_dash_utc_time_str = "20200407T08:28:32Z"
 
   let iso8601_tests =
     let test_of_float_invertible () =
@@ -530,7 +530,6 @@ module Date = struct
       let time = non_int_time |> Float.floor in
       check_float "to_float inverts of_float" time (time |> of_float |> to_float);
       check_true "of_float inverts to_float" @@ eq (time |> of_float) (time |> of_float |> to_float |> of_float);
-      check_float_neq "non-integers don't work" non_int_time (non_int_time |> of_float |> to_float)
     in
 
     let test_only_utc () =
@@ -544,17 +543,40 @@ module Date = struct
     let test_ca333908 () =
       check_float "dash time and no dash time have same float repr"
                   (dash_time_str |> of_string |> to_float)
-                  (no_dash_time_str |> of_string |> to_float)
+                  (no_dash_utc_time_str |> of_string |> to_float)
     in
 
     let test_of_string_invertible_when_no_dashes () =
-      check_string "to_string inverts of_string" no_dash_time_str (no_dash_time_str |> of_string |> to_string);
-      check_true "of_string inverts to_string" (eq (no_dash_time_str |> of_string) (no_dash_time_str |> of_string |> to_string |> of_string));
+      check_string "to_string inverts of_string" no_dash_utc_time_str (no_dash_utc_time_str |> of_string |> to_string);
+      check_true "of_string inverts to_string" (eq (no_dash_utc_time_str |> of_string) (no_dash_utc_time_str |> of_string |> to_string |> of_string));
     in
 
     (* CA-338243 - breaking backwards compatibility will break XC and XRT *)
     let test_to_string_backwards_compatibility () =
-      check_string "to_string is backwards compatible" no_dash_time_str (dash_time_str |> of_string |> to_string);
+      check_string "to_string is backwards compatible" no_dash_utc_time_str
+        (dash_time_str |> of_string |> to_string)
+    in
+
+    let test_localtime_string () =
+      let[@warning "-8"] (Ok (t, _, _)) =
+        Ptime.of_rfc3339 "2020-04-07T09:01:28Z"
+      in
+      let minus_2_hrs = -7200 in
+      let plus_3_hrs = 10800 in
+      let zero_hrs = 0 in
+      check_string "can subtract 2 hours" (_localtime_string (Some minus_2_hrs) t) "20200407T07:01:28";
+      check_string "can add 3 hours" (_localtime_string (Some plus_3_hrs) t) "20200407T12:01:28";
+      check_string "can add None" (_localtime_string None t) "20200407T09:01:28";
+      check_string "can add zero" (_localtime_string (Some zero_hrs) t) "20200407T09:01:28"
+    in
+
+    (* sanity check (on top of test_localtime_string) that localtime produces valid looking output *)
+    let test_ca342171 () =
+      (* no exception is thrown + backward compatible formatting *)
+      let localtime_string = localtime () |> to_string in
+      Alcotest.(check int) "localtime string has correct number of chars"
+        (String.length localtime_string) (String.length no_dash_utc_time_str - 1);
+      Alcotest.(check bool) "localtime string does not contain a Z" false (String.contains localtime_string 'Z')
     in
 
     [ "test_of_float_invertible", `Quick, test_of_float_invertible
@@ -562,6 +584,8 @@ module Date = struct
     ; "test_ca333908", `Quick, test_ca333908
     ; "test_of_string_invertible_when_no_dashes", `Quick, test_of_string_invertible_when_no_dashes
     ; "test_to_string_backwards_compatibility", `Quick, test_to_string_backwards_compatibility
+    ; "test_localtime_string", `Quick, test_localtime_string
+    ; "test_ca342171", `Quick, test_ca342171
     ]
 
   let tests = iso8601_tests


### PR DESCRIPTION
Allow client to call `Date.localtime ()` and
create a datetime based on the localtime.