### PR TITLE
CP-33121: remove dependency of date in encodings tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,4 @@ env:
   jobs:
     - PACKAGE="stdext"
     - PACKAGE="xapi-stdext-encodings"
+    - PACKAGE="xapi-stdext-date"

--- a/lib/xapi-stdext-date/dune
+++ b/lib/xapi-stdext-date/dune
@@ -1,8 +1,16 @@
 (library
   (name xapi_stdext_date)
   (public_name xapi-stdext-date)
+  (modules :standard \ test)
   (libraries astring
              ptime
              ptime.clock.os
              unix)
+)
+
+(test
+  (name test)
+  (package xapi-stdext-date)
+  (modules test)
+  (libraries alcotest xapi-stdext-date)
 )

--- a/lib/xapi-stdext-date/test.ml
+++ b/lib/xapi-stdext-date/test.ml
@@ -1,0 +1,74 @@
+open Xapi_stdext_date.Date
+
+let check_float = Alcotest.(check @@ float 1e-2 )
+let check_float_neq = Alcotest.(check @@ neg @@ float 1e-2)
+let check_string = Alcotest.(check string)
+let check_true str = Alcotest.(check bool) str true
+let dash_time_str = "2020-04-07T08:28:32Z"
+let no_dash_utc_time_str = "20200407T08:28:32Z"
+
+let iso8601_tests =
+  let test_of_float_invertible () =
+    let non_int_time = 1586245987.70200706 in
+    let time = non_int_time |> Float.floor in
+    check_float "to_float inverts of_float" time (time |> of_float |> to_float);
+    check_true "of_float inverts to_float" @@ eq (time |> of_float) (time |> of_float |> to_float |> of_float);
+  in
+
+  let test_only_utc () =
+    let utc = "2020-12-20T18:10:19Z" in
+    let _ = of_string utc in (* UTC is valid *)
+    let non_utc = "2020-12-20T18:10:19+02:00" in
+    let exn = Invalid_argument "date.ml:of_string: 2020-12-20T18:10:19+02:00" in
+    Alcotest.check_raises "only UTC is accepted" exn (fun () ->  of_string non_utc |> ignore)
+  in
+
+  let test_ca333908 () =
+    check_float "dash time and no dash time have same float repr"
+                (dash_time_str |> of_string |> to_float)
+                (no_dash_utc_time_str |> of_string |> to_float)
+  in
+
+  let test_of_string_invertible_when_no_dashes () =
+    check_string "to_string inverts of_string" no_dash_utc_time_str (no_dash_utc_time_str |> of_string |> to_string);
+    check_true "of_string inverts to_string" (eq (no_dash_utc_time_str |> of_string) (no_dash_utc_time_str |> of_string |> to_string |> of_string));
+  in
+
+  (* CA-338243 - breaking backwards compatibility will break XC and XRT *)
+  let test_to_string_backwards_compatibility () =
+    check_string "to_string is backwards compatible" no_dash_utc_time_str
+      (dash_time_str |> of_string |> to_string)
+  in
+
+  let test_localtime_string () =
+    let[@warning "-8"] (Ok (t, _, _)) =
+      Ptime.of_rfc3339 "2020-04-07T09:01:28Z"
+    in
+    let minus_2_hrs = -7200 in
+    let plus_3_hrs = 10800 in
+    let zero_hrs = 0 in
+    check_string "can subtract 2 hours" (_localtime_string (Some minus_2_hrs) t) "20200407T07:01:28";
+    check_string "can add 3 hours" (_localtime_string (Some plus_3_hrs) t) "20200407T12:01:28";
+    check_string "can add None" (_localtime_string None t) "20200407T09:01:28";
+    check_string "can add zero" (_localtime_string (Some zero_hrs) t) "20200407T09:01:28"
+  in
+
+  (* sanity check (on top of test_localtime_string) that localtime produces valid looking output *)
+  let test_ca342171 () =
+    (* no exception is thrown + backward compatible formatting *)
+    let localtime_string = localtime () |> to_string in
+    Alcotest.(check int) "localtime string has correct number of chars"
+      (String.length localtime_string) (String.length no_dash_utc_time_str - 1);
+    Alcotest.(check bool) "localtime string does not contain a Z" false (String.contains localtime_string 'Z')
+  in
+
+  [ "test_of_float_invertible", `Quick, test_of_float_invertible
+  ; "test_only_utc", `Quick, test_only_utc
+  ; "test_ca333908", `Quick, test_ca333908
+  ; "test_of_string_invertible_when_no_dashes", `Quick, test_of_string_invertible_when_no_dashes
+  ; "test_to_string_backwards_compatibility", `Quick, test_to_string_backwards_compatibility
+  ; "test_localtime_string", `Quick, test_localtime_string
+  ; "test_ca342171", `Quick, test_ca342171
+  ]
+
+let () = Alcotest.run "Date" [ "ISO 8601", iso8601_tests ]

--- a/lib/xapi-stdext-encodings/dune
+++ b/lib/xapi-stdext-encodings/dune
@@ -1,14 +1,12 @@
-(* -*- tuareg -*- *)
-let coverage_rewriter =
-  match Sys.getenv "BISECT_ENABLE" with
-  | "YES" -> "(preprocess (pps bisect_ppx -conditional))"
-  | _ -> ""
-| exception Not_found -> ""
-
-let () = Printf.ksprintf Jbuild_plugin.V1.send {|
 (library
   (name xapi_stdext_encodings)
   (public_name xapi-stdext-encodings)
-  %s
+  (modules :standard \ test)
 )
-|} coverage_rewriter
+
+(test
+  (name test)
+  (package xapi-stdext-encodings)
+  (modules test)
+  (libraries alcotest xapi-stdext-encodings)
+)

--- a/lib/xapi-stdext-encodings/test.ml
+++ b/lib/xapi-stdext-encodings/test.ml
@@ -515,15 +515,14 @@ module UTF8_codec = struct include E.UTF8_codec
 
 end
 
-let tests =
-      UCS                   .tests @
-      XML                   .tests @
-      String_validator      .tests @
-      UTF8_UCS_validator    .tests @
-      XML_UTF8_UCS_validator.tests @
-      UTF8_codec            .tests
-
 let () =
   Alcotest.run
-    "suite"
-    [ "Test_encodings", tests ]
+    "Encodings"
+    [
+      "UCS", UCS.tests
+    ; "XML", XML.tests
+    ; "String_validator", String_validator.tests
+    ; "UTF8_UCS_validator", UTF8_UCS_validator.tests
+    ; "XML_UTF8_UCS_validator", XML_UTF8_UCS_validator.tests
+    ; "UTF8_codec", UTF8_codec.tests
+    ]

--- a/lib_test/dune
+++ b/lib_test/dune
@@ -1,8 +1,0 @@
-(test
-  (name test_encodings)
-  (package xapi-stdext-encodings)
-  (libraries
-    alcotest
-    xapi_stdext_encodings
-    xapi-stdext-date)
-)

--- a/lib_test/test_encodings.ml
+++ b/lib_test/test_encodings.ml
@@ -515,90 +515,14 @@ module UTF8_codec = struct include E.UTF8_codec
 
 end
 
-module Date = struct
-  open Xapi_stdext_date.Date
-  let check_float = Alcotest.(check @@ float 1e-2 )
-  let check_float_neq = Alcotest.(check @@ neg @@ float 1e-2)
-  let check_string = Alcotest.(check string)
-  let check_true str = Alcotest.(check bool) str true
-  let dash_time_str = "2020-04-07T08:28:32Z"
-  let no_dash_utc_time_str = "20200407T08:28:32Z"
-
-  let iso8601_tests =
-    let test_of_float_invertible () =
-      let non_int_time = 1586245987.70200706 in
-      let time = non_int_time |> Float.floor in
-      check_float "to_float inverts of_float" time (time |> of_float |> to_float);
-      check_true "of_float inverts to_float" @@ eq (time |> of_float) (time |> of_float |> to_float |> of_float);
-    in
-
-    let test_only_utc () =
-      let utc = "2020-12-20T18:10:19Z" in
-      let _ = of_string utc in (* UTC is valid *)
-      let non_utc = "2020-12-20T18:10:19+02:00" in
-      let exn = Invalid_argument "date.ml:of_string: 2020-12-20T18:10:19+02:00" in
-      Alcotest.check_raises "only UTC is accepted" exn (fun () ->  of_string non_utc |> ignore)
-    in
-
-    let test_ca333908 () =
-      check_float "dash time and no dash time have same float repr"
-                  (dash_time_str |> of_string |> to_float)
-                  (no_dash_utc_time_str |> of_string |> to_float)
-    in
-
-    let test_of_string_invertible_when_no_dashes () =
-      check_string "to_string inverts of_string" no_dash_utc_time_str (no_dash_utc_time_str |> of_string |> to_string);
-      check_true "of_string inverts to_string" (eq (no_dash_utc_time_str |> of_string) (no_dash_utc_time_str |> of_string |> to_string |> of_string));
-    in
-
-    (* CA-338243 - breaking backwards compatibility will break XC and XRT *)
-    let test_to_string_backwards_compatibility () =
-      check_string "to_string is backwards compatible" no_dash_utc_time_str
-        (dash_time_str |> of_string |> to_string)
-    in
-
-    let test_localtime_string () =
-      let[@warning "-8"] (Ok (t, _, _)) =
-        Ptime.of_rfc3339 "2020-04-07T09:01:28Z"
-      in
-      let minus_2_hrs = -7200 in
-      let plus_3_hrs = 10800 in
-      let zero_hrs = 0 in
-      check_string "can subtract 2 hours" (_localtime_string (Some minus_2_hrs) t) "20200407T07:01:28";
-      check_string "can add 3 hours" (_localtime_string (Some plus_3_hrs) t) "20200407T12:01:28";
-      check_string "can add None" (_localtime_string None t) "20200407T09:01:28";
-      check_string "can add zero" (_localtime_string (Some zero_hrs) t) "20200407T09:01:28"
-    in
-
-    (* sanity check (on top of test_localtime_string) that localtime produces valid looking output *)
-    let test_ca342171 () =
-      (* no exception is thrown + backward compatible formatting *)
-      let localtime_string = localtime () |> to_string in
-      Alcotest.(check int) "localtime string has correct number of chars"
-        (String.length localtime_string) (String.length no_dash_utc_time_str - 1);
-      Alcotest.(check bool) "localtime string does not contain a Z" false (String.contains localtime_string 'Z')
-    in
-
-    [ "test_of_float_invertible", `Quick, test_of_float_invertible
-    ; "test_only_utc", `Quick, test_only_utc
-    ; "test_ca333908", `Quick, test_ca333908
-    ; "test_of_string_invertible_when_no_dashes", `Quick, test_of_string_invertible_when_no_dashes
-    ; "test_to_string_backwards_compatibility", `Quick, test_to_string_backwards_compatibility
-    ; "test_localtime_string", `Quick, test_localtime_string
-    ; "test_ca342171", `Quick, test_ca342171
-    ]
-
-  let tests = iso8601_tests
-end
-
 let tests =
       UCS                   .tests @
       XML                   .tests @
       String_validator      .tests @
       UTF8_UCS_validator    .tests @
       XML_UTF8_UCS_validator.tests @
-      UTF8_codec            .tests @
-      Date                  .tests
+      UTF8_codec            .tests
+
 let () =
   Alcotest.run
     "suite"

--- a/xapi-stdext-date.opam
+++ b/xapi-stdext-date.opam
@@ -6,11 +6,15 @@ dev-repo: "git://github.com/xapi-project/stdext.git"
 homepage: "https://xapi-project.github.io/"
 tags: [ "org:xapi-project" ]
 
-build:  [[ "dune" "build" "-p" name "-j" jobs ]]
+build:  [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
 
 depends: [
   "ocaml"
   "dune" {build}
+  "alcotest" {with-test}
   "astring"
   "base-unix"
   "ptime"

--- a/xapi-stdext-encodings.opam
+++ b/xapi-stdext-encodings.opam
@@ -15,7 +15,6 @@ depends: [
   "ocaml"
   "dune" {build}
   "alcotest" {with-test}
-  "xapi-stdext-date" {with-test}
 ]
 synopsis: "A deprecated collection of utility functions - Encodings module"
 description: """


### PR DESCRIPTION
The tests of each package have been moved next to the file with code they're testing, to minimize this sort of dependency to reappear in the future.

The alcotest information for encodings has been changed to try to be more informative instead of repeatedly printing "encodings" for all tests.