### PR TITLE
xapi-stdext-unix: remove proxy()

### DIFF
--- a/lib/xapi-stdext-unix/dune
+++ b/lib/xapi-stdext-unix/dune
@@ -9,6 +9,7 @@
   (libraries
     fd-send-recv
     unix
+    polly
     xapi-stdext-pervasives
     xapi-stdext-std)
 )

--- a/lib/xapi-stdext-unix/unixext.mli
+++ b/lib/xapi-stdext-unix/unixext.mli
@@ -104,7 +104,6 @@ val kill_and_wait : ?signal:int -> ?timeout:float -> int -> unit
  *  a string suitable for logging. *)
 val string_of_signal : int -> string
 
-val proxy : Unix.file_descr -> Unix.file_descr -> unit
 val really_read : Unix.file_descr -> bytes -> int -> int -> unit
 val really_read_string : Unix.file_descr -> int -> string
 

--- a/lib/xapi-stdext-unix/unixext.mli
+++ b/lib/xapi-stdext-unix/unixext.mli
@@ -115,9 +115,23 @@ val really_write : Unix.file_descr -> string -> int -> int -> unit
 val really_write_string : Unix.file_descr -> string -> unit
 val try_read_string : ?limit: int -> Unix.file_descr -> string
 exception Timeout
+
+(** [time_limited_write fd length buf timeout] writes [length] bytes
+from [buf] to [fd] but raises [Timeout] if this takes more than
+[timeout] seconds. When this happens, part of the data may have been
+written to [fd] already and there is no information about which part.*)
 val time_limited_write : Unix.file_descr -> int -> bytes -> float -> unit
+
+(** [time_limited_write_substring] is like [time_limited_write] except
+that the data source is a [string] value *)
 val time_limited_write_substring : Unix.file_descr -> int -> string -> float -> unit
+
+(** [time_limited_read fd length timeout] reads [length] bytes from file
+descriptor [fd] and returns them as a string. It raises [Timeout] if this
+can't be done within [timeout] seconds. This can lead to bytes being
+read from [fd] that are lost because the timeout was hit. *)
 val time_limited_read : Unix.file_descr -> int -> float -> string
+
 val read_data_in_string_chunks : (string -> int -> unit) -> ?block_size:int -> ?max_bytes:int -> Unix.file_descr -> int
 val read_data_in_chunks : (bytes -> int -> unit) -> ?block_size:int -> ?max_bytes:int -> Unix.file_descr -> int
 val spawnvp :

--- a/xapi-stdext-unix.opam
+++ b/xapi-stdext-unix.opam
@@ -12,6 +12,7 @@ depends: [
   "ocaml"
   "dune" {build}
   "base-unix"
+  "polly"
   "fd-send-recv" {>= "2.0.0"}
   "xapi-stdext-pervasives"
   "xapi-stdext-std"


### PR DESCRIPTION
The proxy function has no clients and uses select() which limits the
number of FDs. Remove it.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>