### PR TITLE
XSI-894 date.iso8601.to_float should assume UTC

### DIFF
--- a/lib/xapi-stdext-date/date.ml
+++ b/lib/xapi-stdext-date/date.ml
@@ -87,15 +87,7 @@ let of_float s =
   | None -> invalid_arg (Printf.sprintf "date.ml:of_float: %f" s)
   | Some t -> Ptime.to_date_time t |> of_dt PrintUTC
 
-(* Convert tm in UTC back into calendar time x (using offset between above
-   UTC and localtime fns to determine offset between UTC and localtime, then
-   correcting for this)
-*)
-let to_float t =
-  let (_, _, print_type) = t in
-  match print_type with
-  | PrintLocal -> invalid_arg "date.ml:to_float: expected utc"
-  | PrintUTC   -> to_ptime_t t |> Ptime.to_float_s
+let to_float t = to_ptime_t t |> Ptime.to_float_s
 
 let _localtime current_tz_offset t =
   let tz_offset_s = current_tz_offset |> Option.value ~default:0 in

--- a/lib/xapi-stdext-date/date.ml
+++ b/lib/xapi-stdext-date/date.ml
@@ -15,7 +15,7 @@
 (* ==== RFC822 ==== *)
 type rfc822 = string
 
-let months = [| "Jan"; "Feb"; "Mar"; "Apr"; "May"; "Jun"; 
+let months = [| "Jan"; "Feb"; "Mar"; "Apr"; "May"; "Jun";
                 "Jul"; "Aug"; "Sep"; "Oct"; "Nov"; "Dec" |]
 let days = [| "Sun"; "Mon"; "Tue"; "Wed"; "Thu"; "Fri"; "Sat" |]
 
@@ -30,9 +30,11 @@ let rfc822_to_string x = x
 
 (* ==== ISO8601/RFC3339 ==== *)
 
-type print_type = PrintLocal | PrintUTC
+type print_timezone = Empty | TZ of string
 (* we must store the print_type with iso8601 to handle the case where the local time zone is UTC *)
-type iso8601 = Ptime.date * Ptime.time * print_type
+type iso8601 = Ptime.date * Ptime.time * print_timezone
+
+let utc = TZ "Z"
 
 let of_dt print_type dt = let (date, time) = dt in (date, time, print_type)
 let to_dt (date, time, _) = (date, time)
@@ -57,23 +59,22 @@ let best_effort_iso8601_to_rfc3339 x =
   match tz with
   | None | Some "" ->
     (* the caller didn't specify a tz. we must try to add one so that ptime can at least attempt to parse *)
-    (Printf.sprintf "%sZ" x, PrintLocal)
-  | Some _ ->
-    (* the caller specified a tz. we assume it's UTC because we don't accept anything else *)
-    (x, PrintUTC)
+    (Printf.sprintf "%sZ" x, Empty)
+  | Some tz  ->
+    (x, TZ tz)
 
 let of_string x =
-  let (rfc3339, print_type) = best_effort_iso8601_to_rfc3339 x in
+  let (rfc3339, print_timezone) = best_effort_iso8601_to_rfc3339 x in
   match Ptime.of_rfc3339 rfc3339 |> Ptime.rfc3339_error_to_msg with
   | Error (`Msg e) -> invalid_arg (Printf.sprintf "date.ml:of_string: %s" x)
   | Ok (t, tz, _)  -> match tz with
-                      | None | Some 0 -> Ptime.to_date_time t |> of_dt print_type
+                      | None | Some 0 -> Ptime.to_date_time t |> of_dt print_timezone
                       | Some _        -> invalid_arg (Printf.sprintf "date.ml:of_string: %s" x)
 
 let to_string ((y,mon,d), ((h,min,s), _), print_type) =
   match print_type with
-  | PrintUTC   -> Printf.sprintf "%04i%02i%02iT%02i:%02i:%02iZ" y mon d h min s
-  | PrintLocal -> Printf.sprintf "%04i%02i%02iT%02i:%02i:%02i" y mon d h min s
+  | TZ tz -> Printf.sprintf "%04i%02i%02iT%02i:%02i:%02i%s" y mon d h min s tz
+  | Empty -> Printf.sprintf "%04i%02i%02iT%02i:%02i:%02i" y mon d h min s
 
 let to_ptime_t t =
   match to_dt t |> Ptime.of_date_time with
@@ -85,13 +86,13 @@ let to_ptime_t t =
 let of_float s =
   match Ptime.of_float_s s with
   | None -> invalid_arg (Printf.sprintf "date.ml:of_float: %f" s)
-  | Some t -> Ptime.to_date_time t |> of_dt PrintUTC
+  | Some t -> Ptime.to_date_time t |> of_dt utc
 
 let to_float t = to_ptime_t t |> Ptime.to_float_s
 
 let _localtime current_tz_offset t =
   let tz_offset_s = current_tz_offset |> Option.value ~default:0 in
-  let localtime = t |> Ptime.to_date_time ~tz_offset_s |> of_dt PrintLocal in
+  let localtime = t |> Ptime.to_date_time ~tz_offset_s |> of_dt Empty in
   let (_, (_, localtime_offset), _) = localtime in
   if localtime_offset <> tz_offset_s then
     invalid_arg (

--- a/lib/xapi-stdext-date/date.mli
+++ b/lib/xapi-stdext-date/date.mli
@@ -21,7 +21,8 @@ type iso8601
 (** Convert calendar time [x] (as returned by e.g. Unix.time), to time in UTC. *)
 val of_float : float -> iso8601
 
-(** Convert date/time to a float value: the number of seconds since 00:00:00 UTC, 1 Jan 1970. *)
+(** Convert date/time to a float value: the number of seconds since 00:00:00 UTC, 1 Jan 1970.
+  * Assumes the underlying iso8601 is in UTC *)
 val to_float : iso8601 -> float
 
 (** Convert date/time to an ISO 8601 formatted string. *)

--- a/lib/xapi-stdext-date/test.ml
+++ b/lib/xapi-stdext-date/test.ml
@@ -68,6 +68,8 @@ let iso8601_tests =
     check_string "can process missing tz no dash" missing_tz_no_dash (missing_tz_no_dash |> of_string |> to_string) ;
     check_string "can process missing tz with dashes, but return without dashes" missing_tz_no_dash (missing_tz_dash |> of_string |> to_string) ;
 
+    check_float "to_float assumes UTC" 1607620760. (missing_tz_no_dash |> of_string |> to_float) ;
+
     let localtime' = localtime () in
     check_string "to_string inverts of_string for localtime" (localtime' |> to_string) (localtime' |> to_string |> of_string |> to_string) ;
   in


### PR DESCRIPTION
We must be able to convert all iso8601's to float, in order to avoid
a Java SDK regression