### PR TITLE
CP-34643: deprecate and test functionality in listext

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,5 +1,4 @@
 profile=ocamlformat
-version=0.14.1
 indicate-multiline-delimiters=closing-on-separate-line
 if-then-else=fit-or-vertical
 dock-collection-brackets=true

--- a/lib/xapi-stdext-pervasives/pervasiveext.mli
+++ b/lib/xapi-stdext-pervasives/pervasiveext.mli
@@ -35,7 +35,8 @@ val maybe : ('a -> unit) -> 'a option -> unit
 
 val reraise_if : bool -> (unit -> unit) -> unit
   [@@ocaml.deprecated "Use ignore_exn instead"]
-(** [reraise bool fct] runs [fct ()]. If [not bool] ignores raised exceptions *)
+(** [reraise_if bool fct] runs [fct ()]. If [not bool] ignores raised exceptions *)
+
 val ignore_exn : (unit -> unit) -> unit
 
 val ignore_int : int -> unit

--- a/lib/xapi-stdext-std/dune
+++ b/lib/xapi-stdext-std/dune
@@ -1,12 +1,12 @@
 (library
   (public_name xapi-stdext-std)
   (name  xapi_stdext_std)
-  (modules :standard \ xstringext_test)
+  (modules :standard \ xstringext_test listext_test)
   (libraries uuidm)
 )
 (tests
-  (names xstringext_test)
+  (names xstringext_test listext_test)
   (package xapi-stdext-std)
-  (modules xstringext_test)
+  (modules xstringext_test listext_test)
   (libraries xapi_stdext_std alcotest)
 )

--- a/lib/xapi-stdext-std/listext.ml
+++ b/lib/xapi-stdext-std/listext.ml
@@ -22,7 +22,6 @@ module List = struct include List
   let subset s1 s2 = List.fold_left (&&) true (List.map (fun s->List.mem s s2) s1)
   let set_equiv s1 s2 = (subset s1 s2) && (subset s2 s1)
 
-  let iteri f list = ignore (fold_left (fun i x -> f i x; i+1) 0 list)
   let iteri_right f list = ignore (fold_right (fun x i -> f i x; i+1) list 0)
 
   let rec inv_assoc k = function
@@ -39,12 +38,6 @@ module List = struct include List
   let position pred l =
     let aux (i, is) e = i + 1, if pred e then i :: is else is in
     snd (fold_left aux (0, []) l)
-
-  let mapi f l =
-    let rec aux n = function
-      | h :: t -> let h = f n h in h :: aux (n + 1) t
-      | [] -> [] in
-    aux 0 l
 
   let rev_mapi f l =
     let rec aux n accu = function
@@ -166,9 +159,6 @@ module List = struct include List
   let map_assoc_with_key op al =
     List.map (fun (k, v1) -> (k, op k v1)) al
 
-  (* Like the Lisp cons *)
-  let cons a b = a :: b
-
   (* Could use fold_left to get the same value, but that would necessarily go through the whole list everytime, instead of the first n items, only. *)
   (* ToDo: This is complicated enough to warrant a test. *)
   (* Is it wise to fail silently on negative values?  (They are treated as zero, here.)
@@ -200,9 +190,6 @@ module List = struct include List
   let make_assoc op l = map (fun key -> key, op key) l
 
   let unbox_list l = List.filter_map Fun.id l
-
-  let filter_map f list =
-    unbox_list (map f list)
 
   let restrict_with_default default keys al =
     make_assoc (fun k -> assoc_default k al default) keys

--- a/lib/xapi-stdext-std/listext.ml
+++ b/lib/xapi-stdext-std/listext.ml
@@ -12,22 +12,30 @@
  * GNU Lesser General Public License for more details.
  *)
 
-module List = struct include List
+module List = struct
+  include List
 
   (** Turn a list into a set *)
   let rec setify = function
-    | [] -> []
-    | (x::xs) -> if mem x xs then setify xs else x::(setify xs)
+    | [] ->
+        []
+    | x :: xs ->
+        if mem x xs then setify xs else x :: setify xs
 
-  let subset s1 s2 = List.fold_left (&&) true (List.map (fun s->List.mem s s2) s1)
-  let set_equiv s1 s2 = (subset s1 s2) && (subset s2 s1)
+  let subset s1 s2 =
+    List.fold_left ( && ) true (List.map (fun s -> List.mem s s2) s1)
+
+  let set_equiv s1 s2 = subset s1 s2 && subset s2 s1
 
   let iteri_right f list = iteri f (rev list)
 
   let rec inv_assoc k = function
-    | [] -> raise Not_found
-    | (v, k') :: _ when k = k' -> v
-    | _ :: t -> inv_assoc k t
+    | [] ->
+        raise Not_found
+    | (v, k') :: _ when k = k' ->
+        v
+    | _ :: t ->
+        inv_assoc k t
 
   (* Tail-recursive map. *)
   let map_tr f l = rev (rev_map f l)
@@ -36,13 +44,16 @@ module List = struct include List
     fold_left (fun count e -> count + if pred e then 1 else 0) 0 l
 
   let position pred l =
-    let aux (i, is) e = i + 1, if pred e then i :: is else is in
+    let aux (i, is) e = (i + 1, if pred e then i :: is else is) in
     snd (fold_left aux (0, []) l)
 
   let rev_mapi f l =
     let rec aux n accu = function
-      | h :: t -> aux (n + 1) (f n h :: accu) t
-      | [] -> accu in
+      | h :: t ->
+          aux (n + 1) (f n h :: accu) t
+      | [] ->
+          accu
+    in
     aux 0 [] l
 
   let mapi_tr f l = rev (rev_mapi f l)
@@ -65,97 +76,138 @@ module List = struct include List
     in
     loop 0 list
 
-  let sub i j l = drop i l |> take (j - (max i 0))
+  let sub i j l = drop i l |> take (j - max i 0)
 
-  let rec chop i l = match i, l with
+  let rec chop i l =
+    match (i, l) with
     | j, _ when j < 0 ->
         invalid_arg "chop: index cannot be negative"
-    | 0, l -> [], l
-    | _, h :: t -> (fun (fr, ba) -> h :: fr, ba) (chop (i - 1) t)
-    | _, [] -> invalid_arg "chop: index not in list"
+    | 0, l ->
+        ([], l)
+    | _, h :: t ->
+        (fun (fr, ba) -> (h :: fr, ba)) (chop (i - 1) t)
+    | _, [] ->
+        invalid_arg "chop: index not in list"
 
   let rev_chop i l =
-    let rec aux i fr ba = match i, fr, ba with
+    let rec aux i fr ba =
+      match (i, fr, ba) with
       | i, _, _ when i < 0 ->
           invalid_arg "rev_chop: index cannot be negative"
-      | 0, fr, ba -> (fr, ba)
-      | i, fr, h :: t -> aux (i - 1) (h :: fr) t
-      | _ -> invalid_arg "rev_chop" in
+      | 0, fr, ba ->
+          (fr, ba)
+      | i, fr, h :: t ->
+          aux (i - 1) (h :: fr) t
+      | _ ->
+          invalid_arg "rev_chop"
+    in
     aux i [] l
 
-  let chop_tr i l =
-    (fun (fr, ba) -> rev fr, ba) (rev_chop i l)
+  let chop_tr i l = (fun (fr, ba) -> (rev fr, ba)) (rev_chop i l)
 
-  let rec dice m l = match chop m l with
-    | l, [] -> [l]
-    | l1, l2 -> l1 :: dice m l2
+  let rec dice m l =
+    match chop m l with l, [] -> [l] | l1, l2 -> l1 :: dice m l2
 
-  let remove i l = match rev_chop i l with
-    | rfr, _ :: t -> rev_append rfr t
-    | _ -> invalid_arg "remove"
+  let remove i l =
+    match rev_chop i l with
+    | rfr, _ :: t ->
+        rev_append rfr t
+    | _ ->
+        invalid_arg "remove"
 
-  let extract i l = match rev_chop i l with
-    | rfr, h :: t -> h, rev_append rfr t
-    | _ -> invalid_arg "extract"
+  let extract i l =
+    match rev_chop i l with
+    | rfr, h :: t ->
+        (h, rev_append rfr t)
+    | _ ->
+        invalid_arg "extract"
 
-  let insert i e l = match rev_chop i l with
-      rfr, ba -> rev_append rfr (e :: ba)
+  let insert i e l =
+    match rev_chop i l with rfr, ba -> rev_append rfr (e :: ba)
 
-  let replace i e l = match rev_chop i l with
-    | rfr, _ :: t -> rev_append rfr (e :: t)
-    | _ -> invalid_arg "replace"
+  let replace i e l =
+    match rev_chop i l with
+    | rfr, _ :: t ->
+        rev_append rfr (e :: t)
+    | _ ->
+        invalid_arg "replace"
 
-  let morph i f l = match rev_chop i l with
-    | rfr, h :: t -> rev_append rfr (f h :: t)
-    | _ -> invalid_arg "morph"
+  let morph i f l =
+    match rev_chop i l with
+    | rfr, h :: t ->
+        rev_append rfr (f h :: t)
+    | _ ->
+        invalid_arg "morph"
 
   let rec between e = function
-    | [] -> []
-    | [h] -> [h]
-    | h :: t -> h :: e :: between e t
-
+    | [] ->
+        []
+    | [h] ->
+        [h]
+    | h :: t ->
+        h :: e :: between e t
 
   let between_tr e l =
     let rec aux accu e = function
-      | [] -> rev accu
-      | [h] -> rev (h :: accu)
-      | h :: t -> aux (e :: h :: accu) e t in
+      | [] ->
+          rev accu
+      | [h] ->
+          rev (h :: accu)
+      | h :: t ->
+          aux (e :: h :: accu) e t
+    in
     aux [] e l
 
   let randomize l =
     let extract_rand l = extract (Random.int (length l)) l in
     let rec aux accu = function
-      | [] -> accu
-      | l -> (fun (h, t) -> aux (h :: accu) t) (extract_rand l) in
+      | [] ->
+          accu
+      | l ->
+          (fun (h, t) -> aux (h :: accu) t) (extract_rand l)
+    in
     aux [] l
 
   let rec distribute e = function
-    | (h :: t) as l ->
-      (e :: l) :: (map (fun x -> h :: x) (distribute e t))
-    | [] -> [ [ e ] ]
+    | h :: t as l ->
+        (e :: l) :: map (fun x -> h :: x) (distribute e t)
+    | [] ->
+        [[e]]
 
   let rec permute = function
-    | e :: rest -> flatten (map (distribute e) (permute rest))
-    | [] -> [ [] ]
+    | e :: rest ->
+        flatten (map (distribute e) (permute rest))
+    | [] ->
+        [[]]
 
   let rec aux_rle_eq eq l2 x n = function
-    | [] -> rev ((x, n) :: l2)
-    | h :: t when eq x h -> aux_rle_eq eq l2 x (n + 1) t
-    | h :: t -> aux_rle_eq eq ((x, n) :: l2) h 1 t
+    | [] ->
+        rev ((x, n) :: l2)
+    | h :: t when eq x h ->
+        aux_rle_eq eq l2 x (n + 1) t
+    | h :: t ->
+        aux_rle_eq eq ((x, n) :: l2) h 1 t
 
-  let rle_eq eq l =
-    match l with [] -> [] | h :: t -> aux_rle_eq eq [] h 1 t
+  let rle_eq eq l = match l with [] -> [] | h :: t -> aux_rle_eq eq [] h 1 t
 
   let rle l = rle_eq ( = ) l
 
   let unrle l =
-    let rec aux2 accu i c = match i with
-      | 0 -> accu
-      | i when i>0 -> aux2 (c :: accu) (i - 1) c
-      | _ -> invalid_arg "unrle" in
+    let rec aux2 accu i c =
+      match i with
+      | 0 ->
+          accu
+      | i when i > 0 ->
+          aux2 (c :: accu) (i - 1) c
+      | _ ->
+          invalid_arg "unrle"
+    in
     let rec aux accu = function
-      | [] -> rev accu
-      | (i, c) :: t -> aux (aux2 accu i c) t in
+      | [] ->
+          rev accu
+      | (i, c) :: t ->
+          aux (aux2 accu i c) t
+    in
     aux [] l
 
   let inner fold_left2 base f l1 l2 g =
@@ -164,36 +216,33 @@ module List = struct include List
   let rec is_sorted compare list =
     match list with
     | x :: y :: list ->
-      if compare x y <= 0
-      then is_sorted compare (y :: list)
-      else false
+        if compare x y <= 0 then
+          is_sorted compare (y :: list)
+        else
+          false
     | _ ->
-      true
+        true
 
   let intersect xs ys = List.filter (fun x -> List.mem x ys) xs
 
-  let set_difference a b = List.filter (fun x -> not(List.mem x b)) a
+  let set_difference a b = List.filter (fun x -> not (List.mem x b)) a
 
-  let assoc_default k l d =
-    if List.mem_assoc k l then List.assoc k l else d
+  let assoc_default k l d = if List.mem_assoc k l then List.assoc k l else d
 
-  let map_assoc_with_key op al =
-    List.map (fun (k, v1) -> (k, op k v1)) al
+  let map_assoc_with_key op al = List.map (fun (k, v1) -> (k, op k v1)) al
 
   (* Thanks to sharing we only use linear space. (Roughly double the space needed for the spine of the original list) *)
-  let rec tails = function
-    | [] -> [[]]
-    | (_::xs) as l -> l :: tails xs
+  let rec tails = function [] -> [[]] | _ :: xs as l -> l :: tails xs
 
   let safe_hd l = List.nth_opt l 0
 
   let replace_assoc key new_value existing =
-    (key, new_value) :: (List.filter (fun (k, _) -> k <> key) existing)
+    (key, new_value) :: List.filter (fun (k, _) -> k <> key) existing
 
   let update_assoc update existing =
-    update @ (List.filter (fun (k, _) -> not (List.mem_assoc k update)) existing)
+    update @ List.filter (fun (k, _) -> not (List.mem_assoc k update)) existing
 
-  let make_assoc op l = map (fun key -> key, op key) l
+  let make_assoc op l = map (fun key -> (key, op key)) l
 
   let unbox_list l = List.filter_map Fun.id l
 
@@ -202,9 +251,10 @@ module List = struct include List
 
   let range lower =
     let rec aux accu upper =
-      if lower >= upper
-      then accu
-      else aux (upper-1::accu) (upper-1) in
+      if lower >= upper then
+        accu
+      else
+        aux ((upper - 1) :: accu) (upper - 1)
+    in
     aux []
-
 end

--- a/lib/xapi-stdext-std/listext.ml
+++ b/lib/xapi-stdext-std/listext.ml
@@ -227,7 +227,7 @@ module List = struct
 
   let set_difference a b = List.filter (fun x -> not (List.mem x b)) a
 
-  let assoc_default k l d = if List.mem_assoc k l then List.assoc k l else d
+  let assoc_default k l d = Option.value ~default:d (List.assoc_opt k l)
 
   let map_assoc_with_key op al = List.map (fun (k, v1) -> (k, op k v1)) al
 

--- a/lib/xapi-stdext-std/listext.mli
+++ b/lib/xapi-stdext-std/listext.mli
@@ -16,48 +16,48 @@ sig
   val setify : 'a list -> 'a list
   val subset : 'a list -> 'a list -> bool
   val set_equiv : 'a list -> 'a list -> bool
-  val length : 'a list -> int
-  val hd : 'a list -> 'a
-  val tl : 'a list -> 'a list
-  val nth : 'a list -> int -> 'a
-  val rev : 'a list -> 'a list
-  val append : 'a list -> 'a list -> 'a list
-  val rev_append : 'a list -> 'a list -> 'a list
-  val concat : 'a list list -> 'a list
-  val flatten : 'a list list -> 'a list
-  val iter : ('a -> unit) -> 'a list -> unit
-  val map : ('a -> 'b) -> 'a list -> 'b list
-  val rev_map : ('a -> 'b) -> 'a list -> 'b list
-  val fold_left : ('a -> 'b -> 'a) -> 'a -> 'b list -> 'a
-  val fold_right : ('a -> 'b -> 'b) -> 'a list -> 'b -> 'b
-  val iter2 : ('a -> 'b -> unit) -> 'a list -> 'b list -> unit
-  val map2 : ('a -> 'b -> 'c) -> 'a list -> 'b list -> 'c list
-  val rev_map2 : ('a -> 'b -> 'c) -> 'a list -> 'b list -> 'c list
-  val fold_left2 : ('a -> 'b -> 'c -> 'a) -> 'a -> 'b list -> 'c list -> 'a
+  val length : 'a list -> int [@@deprecated "Use Stdlib.List instead"]
+  val hd : 'a list -> 'a [@@deprecated "Use Stdlib.List instead"]
+  val tl : 'a list -> 'a list [@@deprecated "Use Stdlib.List instead"]
+  val nth : 'a list -> int -> 'a [@@deprecated "Use Stdlib.List instead"]
+  val rev : 'a list -> 'a list [@@deprecated "Use Stdlib.List instead"]
+  val append : 'a list -> 'a list -> 'a list [@@deprecated "Use Stdlib.List instead"]
+  val rev_append : 'a list -> 'a list -> 'a list [@@deprecated "Use Stdlib.List instead"]
+  val concat : 'a list list -> 'a list [@@deprecated "Use Stdlib.List instead"]
+  val flatten : 'a list list -> 'a list [@@deprecated "Use Stdlib.List instead"]
+  val iter : ('a -> unit) -> 'a list -> unit [@@deprecated "Use Stdlib.List instead"]
+  val map : ('a -> 'b) -> 'a list -> 'b list [@@deprecated "Use Stdlib.List instead"]
+  val rev_map : ('a -> 'b) -> 'a list -> 'b list [@@deprecated "Use Stdlib.List instead"]
+  val fold_left : ('a -> 'b -> 'a) -> 'a -> 'b list -> 'a [@@deprecated "Use Stdlib.List instead"]
+  val fold_right : ('a -> 'b -> 'b) -> 'a list -> 'b -> 'b [@@deprecated "Use Stdlib.List instead"]
+  val iter2 : ('a -> 'b -> unit) -> 'a list -> 'b list -> unit [@@deprecated "Use Stdlib.List instead"]
+  val map2 : ('a -> 'b -> 'c) -> 'a list -> 'b list -> 'c list [@@deprecated "Use Stdlib.List instead"]
+  val rev_map2 : ('a -> 'b -> 'c) -> 'a list -> 'b list -> 'c list [@@deprecated "Use Stdlib.List instead"]
+  val fold_left2 : ('a -> 'b -> 'c -> 'a) -> 'a -> 'b list -> 'c list -> 'a [@@deprecated "Use Stdlib.List instead"]
   val fold_right2 :
-    ('a -> 'b -> 'c -> 'c) -> 'a list -> 'b list -> 'c -> 'c
-  val for_all : ('a -> bool) -> 'a list -> bool
-  val exists : ('a -> bool) -> 'a list -> bool
-  val for_all2 : ('a -> 'b -> bool) -> 'a list -> 'b list -> bool
-  val exists2 : ('a -> 'b -> bool) -> 'a list -> 'b list -> bool
-  val mem : 'a -> 'a list -> bool
-  val memq : 'a -> 'a list -> bool
-  val find : ('a -> bool) -> 'a list -> 'a
-  val filter : ('a -> bool) -> 'a list -> 'a list
-  val find_all : ('a -> bool) -> 'a list -> 'a list
-  val partition : ('a -> bool) -> 'a list -> 'a list * 'a list
-  val assoc : 'a -> ('a * 'b) list -> 'b
-  val assq : 'a -> ('a * 'b) list -> 'b
-  val mem_assoc : 'a -> ('a * 'b) list -> bool
-  val mem_assq : 'a -> ('a * 'b) list -> bool
-  val remove_assoc : 'a -> ('a * 'b) list -> ('a * 'b) list
-  val remove_assq : 'a -> ('a * 'b) list -> ('a * 'b) list
-  val split : ('a * 'b) list -> 'a list * 'b list
-  val combine : 'a list -> 'b list -> ('a * 'b) list
-  val sort : ('a -> 'a -> int) -> 'a list -> 'a list
-  val stable_sort : ('a -> 'a -> int) -> 'a list -> 'a list
-  val fast_sort : ('a -> 'a -> int) -> 'a list -> 'a list
-  val merge : ('a -> 'a -> int) -> 'a list -> 'a list -> 'a list
+    ('a -> 'b -> 'c -> 'c) -> 'a list -> 'b list -> 'c -> 'c [@@deprecated "Use Stdlib.List instead"]
+  val for_all : ('a -> bool) -> 'a list -> bool [@@deprecated "Use Stdlib.List instead"]
+  val exists : ('a -> bool) -> 'a list -> bool [@@deprecated "Use Stdlib.List instead"]
+  val for_all2 : ('a -> 'b -> bool) -> 'a list -> 'b list -> bool [@@deprecated "Use Stdlib.List instead"]
+  val exists2 : ('a -> 'b -> bool) -> 'a list -> 'b list -> bool [@@deprecated "Use Stdlib.List instead"]
+  val mem : 'a -> 'a list -> bool [@@deprecated "Use Stdlib.List instead"]
+  val memq : 'a -> 'a list -> bool [@@deprecated "Use Stdlib.List instead"]
+  val find : ('a -> bool) -> 'a list -> 'a [@@deprecated "Use Stdlib.List instead"]
+  val filter : ('a -> bool) -> 'a list -> 'a list [@@deprecated "Use Stdlib.List instead"]
+  val find_all : ('a -> bool) -> 'a list -> 'a list [@@deprecated "Use Stdlib.List instead"]
+  val partition : ('a -> bool) -> 'a list -> 'a list * 'a list [@@deprecated "Use Stdlib.List instead"]
+  val assoc : 'a -> ('a * 'b) list -> 'b [@@deprecated "Use Stdlib.List instead"]
+  val assq : 'a -> ('a * 'b) list -> 'b [@@deprecated "Use Stdlib.List instead"]
+  val mem_assoc : 'a -> ('a * 'b) list -> bool [@@deprecated "Use Stdlib.List instead"]
+  val mem_assq : 'a -> ('a * 'b) list -> bool [@@deprecated "Use Stdlib.List instead"]
+  val remove_assoc : 'a -> ('a * 'b) list -> ('a * 'b) list [@@deprecated "Use Stdlib.List instead"]
+  val remove_assq : 'a -> ('a * 'b) list -> ('a * 'b) list [@@deprecated "Use Stdlib.List instead"]
+  val split : ('a * 'b) list -> 'a list * 'b list [@@deprecated "Use Stdlib.List instead"]
+  val combine : 'a list -> 'b list -> ('a * 'b) list [@@deprecated "Use Stdlib.List instead"]
+  val sort : ('a -> 'a -> int) -> 'a list -> 'a list [@@deprecated "Use Stdlib.List instead"]
+  val stable_sort : ('a -> 'a -> int) -> 'a list -> 'a list [@@deprecated "Use Stdlib.List instead"]
+  val fast_sort : ('a -> 'a -> int) -> 'a list -> 'a list [@@deprecated "Use Stdlib.List instead"]
+  val merge : ('a -> 'a -> int) -> 'a list -> 'a list -> 'a list [@@deprecated "Use Stdlib.List instead"]
 
   (** Perform a lookup on an association list of (value, key) pairs. *)
   val inv_assoc : 'a -> ('b * 'a) list -> 'b
@@ -73,9 +73,9 @@ sig
 
   (** Map the given function over a list, supplying the integer
       	    index as well as the element value. *)
-  val mapi : (int -> 'a -> 'b) -> 'a list -> 'b list
+  val mapi : (int -> 'a -> 'b) -> 'a list -> 'b list [@@deprecated "Use Stdlib.List instead"]
 
-  val iteri : (int -> 'a -> unit) -> 'a list -> unit
+  val iteri : (int -> 'a -> unit) -> 'a list -> unit [@@deprecated "Use Stdlib.List instead"]
 
   val iteri_right : (int -> 'a -> unit) -> 'a list -> unit
 
@@ -153,7 +153,7 @@ sig
       	    non-optional values B [b1; ...; bn], with m >= n. For each value
       	    a in list A, list B contains a corresponding value b if and only
       	    if the application of (f a) results in Some b.  *)
-  val filter_map : ('a -> 'b option) -> 'a list -> 'b list
+  val filter_map : ('a -> 'b option) -> 'a list -> 'b list [@@deprecated "Use Stdlib.List instead"]
 
   (** Returns true if and only if the given list is in sorted order
       	    according to the given comparison function.  *)
@@ -174,7 +174,7 @@ sig
   val map_assoc_with_key : ('k -> 'v1 -> 'v2) -> ('k * 'v1) list -> ('k * 'v2) list
 
   (* Like Lisp cons*)
-  val cons : 'a -> 'a list -> 'a list
+  val cons : 'a -> 'a list -> 'a list [@@deprecated "Use Stdlib.List instead"]
 
   (** [take n list] returns the first [n] elements of [list] (or less if list
       	    is shorter).*)

--- a/lib/xapi-stdext-std/listext.mli
+++ b/lib/xapi-stdext-std/listext.mli
@@ -85,20 +85,26 @@ sig
   (** Tail-recursive [mapi]. *)
   val mapi_tr : (int -> 'a -> 'b) -> 'a list -> 'b list
 
-  (** Split a list at the given index to give a pair of lists. *)
+  (** [chop k l] splits [l] at index [k] to return a pair of lists. Raises
+      invalid_arg when [i] is negative or greater than the length of [l]. *)
   val chop : int -> 'a list -> 'a list * 'a list
 
-  (** Split a list at the given index to give a pair of lists, the first in
-      		  reverse order. *)
+  (** [rev_chop k l] splits [l] at index [k] to return a pair of lists, the
+      first in reverse order. Raises invalid_arg when [i] is negative or
+      greater than the length of [l]. *)
   val rev_chop : int -> 'a list -> 'a list * 'a list
 
   (** Tail-recursive [chop]. *)
   val chop_tr : int -> 'a list -> 'a list * 'a list
 
-  (** Split a list into lists with the given number of elements. *)
+  (** [dice k l] splits [l] into lists with [k] elements each. Raises
+      invalid_arg if [List.length l] is not divisible by [k]. *)
   val dice : int -> 'a list -> 'a list list
 
-  (** Extract the sub-list between the given indices. *)
+  (** [sub from to l] returns the sub-list of [l] that starts at index [from]
+      and ends at [to] or an empty list if [to] is equal or less than [from].
+      Negative indices are treated as 0 and indeces higher than [List.length l
+      - 1] are treated as [List.length l - 1]. *)
   val sub : int -> int -> 'a list -> 'a list
 
   (** Remove the element at the given index. *)
@@ -180,8 +186,13 @@ sig
       	    is shorter).*)
   val take : int -> 'a list -> 'a list
 
+  (** [drop n list] returns the list without the first [n] elements of [list]
+      (or [] if list is shorter). *)
+  val drop : int -> 'a list -> 'a list
+
   val tails : 'a list -> ('a list) list
   val safe_hd : 'a list -> 'a option
+    [@@deprecated "Use List.nth_opt list 0 instead"]
 
   (** Replace the value belonging to a key in an association list. Adds the key/value pair
       	 *  if it does not yet exist in the list. If the same key occurs multiple time in the original

--- a/lib/xapi-stdext-std/listext.mli
+++ b/lib/xapi-stdext-std/listext.mli
@@ -11,211 +11,292 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  *)
-module List :
-sig
+module List : sig
   val setify : 'a list -> 'a list
+
   val subset : 'a list -> 'a list -> bool
+
   val set_equiv : 'a list -> 'a list -> bool
+
   val length : 'a list -> int [@@deprecated "Use Stdlib.List instead"]
+
   val hd : 'a list -> 'a [@@deprecated "Use Stdlib.List instead"]
+
   val tl : 'a list -> 'a list [@@deprecated "Use Stdlib.List instead"]
+
   val nth : 'a list -> int -> 'a [@@deprecated "Use Stdlib.List instead"]
+
   val rev : 'a list -> 'a list [@@deprecated "Use Stdlib.List instead"]
-  val append : 'a list -> 'a list -> 'a list [@@deprecated "Use Stdlib.List instead"]
-  val rev_append : 'a list -> 'a list -> 'a list [@@deprecated "Use Stdlib.List instead"]
+
+  val append : 'a list -> 'a list -> 'a list
+    [@@deprecated "Use Stdlib.List instead"]
+
+  val rev_append : 'a list -> 'a list -> 'a list
+    [@@deprecated "Use Stdlib.List instead"]
+
   val concat : 'a list list -> 'a list [@@deprecated "Use Stdlib.List instead"]
+
   val flatten : 'a list list -> 'a list [@@deprecated "Use Stdlib.List instead"]
-  val iter : ('a -> unit) -> 'a list -> unit [@@deprecated "Use Stdlib.List instead"]
-  val map : ('a -> 'b) -> 'a list -> 'b list [@@deprecated "Use Stdlib.List instead"]
-  val rev_map : ('a -> 'b) -> 'a list -> 'b list [@@deprecated "Use Stdlib.List instead"]
-  val fold_left : ('a -> 'b -> 'a) -> 'a -> 'b list -> 'a [@@deprecated "Use Stdlib.List instead"]
-  val fold_right : ('a -> 'b -> 'b) -> 'a list -> 'b -> 'b [@@deprecated "Use Stdlib.List instead"]
-  val iter2 : ('a -> 'b -> unit) -> 'a list -> 'b list -> unit [@@deprecated "Use Stdlib.List instead"]
-  val map2 : ('a -> 'b -> 'c) -> 'a list -> 'b list -> 'c list [@@deprecated "Use Stdlib.List instead"]
-  val rev_map2 : ('a -> 'b -> 'c) -> 'a list -> 'b list -> 'c list [@@deprecated "Use Stdlib.List instead"]
-  val fold_left2 : ('a -> 'b -> 'c -> 'a) -> 'a -> 'b list -> 'c list -> 'a [@@deprecated "Use Stdlib.List instead"]
-  val fold_right2 :
-    ('a -> 'b -> 'c -> 'c) -> 'a list -> 'b list -> 'c -> 'c [@@deprecated "Use Stdlib.List instead"]
-  val for_all : ('a -> bool) -> 'a list -> bool [@@deprecated "Use Stdlib.List instead"]
-  val exists : ('a -> bool) -> 'a list -> bool [@@deprecated "Use Stdlib.List instead"]
-  val for_all2 : ('a -> 'b -> bool) -> 'a list -> 'b list -> bool [@@deprecated "Use Stdlib.List instead"]
-  val exists2 : ('a -> 'b -> bool) -> 'a list -> 'b list -> bool [@@deprecated "Use Stdlib.List instead"]
+
+  val iter : ('a -> unit) -> 'a list -> unit
+    [@@deprecated "Use Stdlib.List instead"]
+
+  val map : ('a -> 'b) -> 'a list -> 'b list
+    [@@deprecated "Use Stdlib.List instead"]
+
+  val rev_map : ('a -> 'b) -> 'a list -> 'b list
+    [@@deprecated "Use Stdlib.List instead"]
+
+  val fold_left : ('a -> 'b -> 'a) -> 'a -> 'b list -> 'a
+    [@@deprecated "Use Stdlib.List instead"]
+
+  val fold_right : ('a -> 'b -> 'b) -> 'a list -> 'b -> 'b
+    [@@deprecated "Use Stdlib.List instead"]
+
+  val iter2 : ('a -> 'b -> unit) -> 'a list -> 'b list -> unit
+    [@@deprecated "Use Stdlib.List instead"]
+
+  val map2 : ('a -> 'b -> 'c) -> 'a list -> 'b list -> 'c list
+    [@@deprecated "Use Stdlib.List instead"]
+
+  val rev_map2 : ('a -> 'b -> 'c) -> 'a list -> 'b list -> 'c list
+    [@@deprecated "Use Stdlib.List instead"]
+
+  val fold_left2 : ('a -> 'b -> 'c -> 'a) -> 'a -> 'b list -> 'c list -> 'a
+    [@@deprecated "Use Stdlib.List instead"]
+
+  val fold_right2 : ('a -> 'b -> 'c -> 'c) -> 'a list -> 'b list -> 'c -> 'c
+    [@@deprecated "Use Stdlib.List instead"]
+
+  val for_all : ('a -> bool) -> 'a list -> bool
+    [@@deprecated "Use Stdlib.List instead"]
+
+  val exists : ('a -> bool) -> 'a list -> bool
+    [@@deprecated "Use Stdlib.List instead"]
+
+  val for_all2 : ('a -> 'b -> bool) -> 'a list -> 'b list -> bool
+    [@@deprecated "Use Stdlib.List instead"]
+
+  val exists2 : ('a -> 'b -> bool) -> 'a list -> 'b list -> bool
+    [@@deprecated "Use Stdlib.List instead"]
+
   val mem : 'a -> 'a list -> bool [@@deprecated "Use Stdlib.List instead"]
+
   val memq : 'a -> 'a list -> bool [@@deprecated "Use Stdlib.List instead"]
-  val find : ('a -> bool) -> 'a list -> 'a [@@deprecated "Use Stdlib.List instead"]
-  val filter : ('a -> bool) -> 'a list -> 'a list [@@deprecated "Use Stdlib.List instead"]
-  val find_all : ('a -> bool) -> 'a list -> 'a list [@@deprecated "Use Stdlib.List instead"]
-  val partition : ('a -> bool) -> 'a list -> 'a list * 'a list [@@deprecated "Use Stdlib.List instead"]
-  val assoc : 'a -> ('a * 'b) list -> 'b [@@deprecated "Use Stdlib.List instead"]
+
+  val find : ('a -> bool) -> 'a list -> 'a
+    [@@deprecated "Use Stdlib.List instead"]
+
+  val filter : ('a -> bool) -> 'a list -> 'a list
+    [@@deprecated "Use Stdlib.List instead"]
+
+  val find_all : ('a -> bool) -> 'a list -> 'a list
+    [@@deprecated "Use Stdlib.List instead"]
+
+  val partition : ('a -> bool) -> 'a list -> 'a list * 'a list
+    [@@deprecated "Use Stdlib.List instead"]
+
+  val assoc : 'a -> ('a * 'b) list -> 'b
+    [@@deprecated "Use Stdlib.List instead"]
+
   val assq : 'a -> ('a * 'b) list -> 'b [@@deprecated "Use Stdlib.List instead"]
-  val mem_assoc : 'a -> ('a * 'b) list -> bool [@@deprecated "Use Stdlib.List instead"]
-  val mem_assq : 'a -> ('a * 'b) list -> bool [@@deprecated "Use Stdlib.List instead"]
-  val remove_assoc : 'a -> ('a * 'b) list -> ('a * 'b) list [@@deprecated "Use Stdlib.List instead"]
-  val remove_assq : 'a -> ('a * 'b) list -> ('a * 'b) list [@@deprecated "Use Stdlib.List instead"]
-  val split : ('a * 'b) list -> 'a list * 'b list [@@deprecated "Use Stdlib.List instead"]
-  val combine : 'a list -> 'b list -> ('a * 'b) list [@@deprecated "Use Stdlib.List instead"]
-  val sort : ('a -> 'a -> int) -> 'a list -> 'a list [@@deprecated "Use Stdlib.List instead"]
-  val stable_sort : ('a -> 'a -> int) -> 'a list -> 'a list [@@deprecated "Use Stdlib.List instead"]
-  val fast_sort : ('a -> 'a -> int) -> 'a list -> 'a list [@@deprecated "Use Stdlib.List instead"]
-  val merge : ('a -> 'a -> int) -> 'a list -> 'a list -> 'a list [@@deprecated "Use Stdlib.List instead"]
 
-  (** Perform a lookup on an association list of (value, key) pairs. *)
+  val mem_assoc : 'a -> ('a * 'b) list -> bool
+    [@@deprecated "Use Stdlib.List instead"]
+
+  val mem_assq : 'a -> ('a * 'b) list -> bool
+    [@@deprecated "Use Stdlib.List instead"]
+
+  val remove_assoc : 'a -> ('a * 'b) list -> ('a * 'b) list
+    [@@deprecated "Use Stdlib.List instead"]
+
+  val remove_assq : 'a -> ('a * 'b) list -> ('a * 'b) list
+    [@@deprecated "Use Stdlib.List instead"]
+
+  val split : ('a * 'b) list -> 'a list * 'b list
+    [@@deprecated "Use Stdlib.List instead"]
+
+  val combine : 'a list -> 'b list -> ('a * 'b) list
+    [@@deprecated "Use Stdlib.List instead"]
+
+  val sort : ('a -> 'a -> int) -> 'a list -> 'a list
+    [@@deprecated "Use Stdlib.List instead"]
+
+  val stable_sort : ('a -> 'a -> int) -> 'a list -> 'a list
+    [@@deprecated "Use Stdlib.List instead"]
+
+  val fast_sort : ('a -> 'a -> int) -> 'a list -> 'a list
+    [@@deprecated "Use Stdlib.List instead"]
+
+  val merge : ('a -> 'a -> int) -> 'a list -> 'a list -> 'a list
+    [@@deprecated "Use Stdlib.List instead"]
+
   val inv_assoc : 'a -> ('b * 'a) list -> 'b
+  (** Perform a lookup on an association list of (value, key) pairs. *)
 
-  (** A tail-recursive map. *)
   val map_tr : ('a -> 'b) -> 'a list -> 'b list
+  (** A tail-recursive map. *)
 
-  (** Count the number of list elements matching the given predicate. *)
   val count : ('a -> bool) -> 'a list -> int
+  (** Count the number of list elements matching the given predicate. *)
 
-  (** Find the indices of all elements matching the given predicate. *)
   val position : ('a -> bool) -> 'a list -> int list
+  (** Find the indices of all elements matching the given predicate. *)
 
+  val mapi : (int -> 'a -> 'b) -> 'a list -> 'b list
+    [@@deprecated "Use Stdlib.List instead"]
   (** Map the given function over a list, supplying the integer
       	    index as well as the element value. *)
-  val mapi : (int -> 'a -> 'b) -> 'a list -> 'b list [@@deprecated "Use Stdlib.List instead"]
 
-  val iteri : (int -> 'a -> unit) -> 'a list -> unit [@@deprecated "Use Stdlib.List instead"]
+  val iteri : (int -> 'a -> unit) -> 'a list -> unit
+    [@@deprecated "Use Stdlib.List instead"]
 
   val iteri_right : (int -> 'a -> unit) -> 'a list -> unit
 
-  (** Map the given function over a list in reverse order. *)
   val rev_mapi : (int -> 'a -> 'b) -> 'a list -> 'b list
+  (** Map the given function over a list in reverse order. *)
 
-  (** Tail-recursive [mapi]. *)
   val mapi_tr : (int -> 'a -> 'b) -> 'a list -> 'b list
+  (** Tail-recursive [mapi]. *)
 
+  val chop : int -> 'a list -> 'a list * 'a list
   (** [chop k l] splits [l] at index [k] to return a pair of lists. Raises
       invalid_arg when [i] is negative or greater than the length of [l]. *)
-  val chop : int -> 'a list -> 'a list * 'a list
 
+  val rev_chop : int -> 'a list -> 'a list * 'a list
   (** [rev_chop k l] splits [l] at index [k] to return a pair of lists, the
       first in reverse order. Raises invalid_arg when [i] is negative or
       greater than the length of [l]. *)
-  val rev_chop : int -> 'a list -> 'a list * 'a list
 
-  (** Tail-recursive [chop]. *)
   val chop_tr : int -> 'a list -> 'a list * 'a list
+  (** Tail-recursive [chop]. *)
 
+  val dice : int -> 'a list -> 'a list list
   (** [dice k l] splits [l] into lists with [k] elements each. Raises
       invalid_arg if [List.length l] is not divisible by [k]. *)
-  val dice : int -> 'a list -> 'a list list
 
+  val sub : int -> int -> 'a list -> 'a list
   (** [sub from to l] returns the sub-list of [l] that starts at index [from]
       and ends at [to] or an empty list if [to] is equal or less than [from].
       Negative indices are treated as 0 and indeces higher than [List.length l
       - 1] are treated as [List.length l - 1]. *)
-  val sub : int -> int -> 'a list -> 'a list
 
-  (** Remove the element at the given index. *)
   val remove : int -> 'a list -> 'a list
+  (** Remove the element at the given index. *)
 
   (** Extract the element at the given index, returning the element and the
       		list without that element. *)
-  val extract : int -> 'a list -> 'a * 'a list
 
-  (** Insert the given element at the given index. *)
   val insert : int -> 'a -> 'a list -> 'a list
+  (** Insert the given element at the given index. *)
 
-  (** Replace the element at the given index with the given value. *)
   val replace : int -> 'a -> 'a list -> 'a list
+  (** Replace the element at the given index with the given value. *)
 
-  (** Apply the given function to the element at the given index. *)
   val morph : int -> ('a -> 'a) -> 'a list -> 'a list
+  (** Apply the given function to the element at the given index. *)
 
+  val between : 'a -> 'a list -> 'a list
   (** Insert the element [e] between every pair of adjacent elements in the
       	    given list. *)
-  val between : 'a -> 'a list -> 'a list
 
-  (** Tail-recursive [between]. *)
   val between_tr : 'a -> 'a list -> 'a list
+  (** Tail-recursive [between]. *)
 
-  (** Generate a random permutation of the given list. *)
   val randomize : 'a list -> 'a list
+  (** Generate a random permutation of the given list. *)
 
+  val distribute : 'a -> 'a list -> 'a list list
   (** Distribute the given element over the given list, returning a list of
       	    lists with the new element in each position. *)
-  val distribute : 'a -> 'a list -> 'a list list
 
-  (** Generate all permutations of the given list. *)
   val permute : 'a list -> 'a list list
+  (** Generate all permutations of the given list. *)
 
-  (** Run-length encode the given list using the given equality function. *)
   val rle_eq : ('a -> 'a -> bool) -> 'a list -> ('a * int) list
+  (** Run-length encode the given list using the given equality function. *)
 
-  (** Run-length encode the given list using built-in equality. *)
   val rle : 'a list -> ('a * int) list
+  (** Run-length encode the given list using built-in equality. *)
 
-  (** Decode a run-length encoded list. *)
   val unrle : (int * 'a) list -> 'a list
+  (** Decode a run-length encoded list. *)
 
-  (** Compute the inner product of two lists. *)
   val inner :
-    (('a -> 'b -> 'c -> 'd) -> 'e -> 'f -> 'g -> 'h) ->
-    'e -> ('b -> 'c -> 'i) -> 'f -> 'g -> ('a -> 'i -> 'd) -> 'h
+       (('a -> 'b -> 'c -> 'd) -> 'e -> 'f -> 'g -> 'h)
+    -> 'e
+    -> ('b -> 'c -> 'i)
+    -> 'f
+    -> 'g
+    -> ('a -> 'i -> 'd)
+    -> 'h
+  (** Compute the inner product of two lists. *)
 
+  val filter_map : ('a -> 'b option) -> 'a list -> 'b list
+    [@@deprecated "Use Stdlib.List instead"]
   (** Applies a function f that generates optional values, to each
       	    of the items in a list A [a1; ...; am], generating a new list of
       	    non-optional values B [b1; ...; bn], with m >= n. For each value
       	    a in list A, list B contains a corresponding value b if and only
       	    if the application of (f a) results in Some b.  *)
-  val filter_map : ('a -> 'b option) -> 'a list -> 'b list [@@deprecated "Use Stdlib.List instead"]
 
+  val is_sorted : ('a -> 'a -> int) -> 'a list -> bool
   (** Returns true if and only if the given list is in sorted order
       	    according to the given comparison function.  *)
-  val is_sorted : ('a -> 'a -> int) -> 'a list -> bool
 
-  (** Returns the intersection of two lists. *)
   val intersect : 'a list -> 'a list -> 'a list
+  (** Returns the intersection of two lists. *)
 
-  (** Returns the set difference of two lists *)
   val set_difference : 'a list -> 'a list -> 'a list
+  (** Returns the set difference of two lists *)
 
+  val assoc_default : 'a -> ('a * 'b) list -> 'b -> 'b
   (** Act as List.assoc, but return the given default value if the
       	    key is not in the list. *)
-  val assoc_default : 'a -> ('a * 'b) list -> 'b -> 'b
 
+  val map_assoc_with_key :
+    ('k -> 'v1 -> 'v2) -> ('k * 'v1) list -> ('k * 'v2) list
   (** [map_assoc_with_key op al] transforms every value in [al] based on the
       	    key and the value using [op]. *)
-  val map_assoc_with_key : ('k -> 'v1 -> 'v2) -> ('k * 'v1) list -> ('k * 'v2) list
 
   (* Like Lisp cons*)
   val cons : 'a -> 'a list -> 'a list [@@deprecated "Use Stdlib.List instead"]
 
+  val take : int -> 'a list -> 'a list
   (** [take n list] returns the first [n] elements of [list] (or less if list
       	    is shorter).*)
-  val take : int -> 'a list -> 'a list
 
+  val drop : int -> 'a list -> 'a list
   (** [drop n list] returns the list without the first [n] elements of [list]
       (or [] if list is shorter). *)
-  val drop : int -> 'a list -> 'a list
 
-  val tails : 'a list -> ('a list) list
+  val tails : 'a list -> 'a list list
+
   val safe_hd : 'a list -> 'a option
     [@@deprecated "Use List.nth_opt list 0 instead"]
 
+  val replace_assoc : 'a -> 'b -> ('a * 'b) list -> ('a * 'b) list
   (** Replace the value belonging to a key in an association list. Adds the key/value pair
       	 *  if it does not yet exist in the list. If the same key occurs multiple time in the original
       	 *  list, all occurances are removed and replaced by a single new key/value pair.
       	 *  This function is useful is the assoc list is used as a lightweight map/hashtable/dictonary. *)
-  val replace_assoc : 'a -> 'b -> ('a * 'b) list -> ('a * 'b) list
 
+  val update_assoc : ('a * 'b) list -> ('a * 'b) list -> ('a * 'b) list
   (** Includes everything from [update] and all key/value pairs from [existing] for
       	 *  which the key does not exist in [update]. In other words, it is like [replace_assoc]
       	 *  but then given a whole assoc list of updates rather than a single key/value pair. *)
-  val update_assoc : ('a * 'b) list -> ('a * 'b) list -> ('a * 'b) list
 
   val make_assoc : ('a -> 'b) -> 'a list -> ('a * 'b) list
 
-  (** Unbox all values from the option list. *)
   val unbox_list : 'a option list -> 'a list
+  (** Unbox all values from the option list. *)
 
+  val restrict_with_default : 'v -> 'k list -> ('k * 'v) list -> ('k * 'v) list
   (** [restrict_with_default default keys al] makes a new association map
       	    from [keys] to previous values for [keys] in [al]. If a key is not found
       	    in [al], the [default] is used. *)
-  val restrict_with_default : 'v -> 'k list -> ('k * 'v) list -> ('k * 'v) list
 
+  val range : int -> int -> int list
   (** range lower upper = [lower; lower + 1; ...; upper - 1]
       	    Returns the empty list if lower >= upper. *)
-  val range : int -> int -> int list
 end

--- a/lib/xapi-stdext-std/listext_test.ml
+++ b/lib/xapi-stdext-std/listext_test.ml
@@ -1,0 +1,181 @@
+(* Copyright (C) Citrix Systems Inc.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License as published
+   by the Free Software Foundation; version 2.1 only. with the special
+   exception on linking described in file LICENSE.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
+ *)
+
+module Listext = Xapi_stdext_std.Listext.List
+
+let test_list tested_f (name, case, expected) =
+  let check () = Alcotest.(check @@ list int) name expected (tested_f case) in
+  (name, `Quick, check)
+
+let test_option tested_f (name, case, expected) =
+  let check () = Alcotest.(check @@ option int) name expected (tested_f case) in
+  (name, `Quick, check)
+
+let test_chopped_list tested_f (name, case, expected) =
+  let check () =
+    Alcotest.(check @@ pair (list int) (list int)) name expected (tested_f case)
+  in
+  (name, `Quick, check)
+
+let test_error tested_f (name, case, expected) =
+  let check () = Alcotest.check_raises name expected (tested_f case) in
+  (name, `Quick, check)
+
+let test_iteri_right =
+  let specs =
+    [
+      ([], [])
+    ; ([0], [(0, 0)])
+    ; ([2; 4], [(0, 4); (1, 2)])
+    ; ([2; 4; 8], [(0, 8); (1, 4); (2, 2)])
+    ]
+  in
+  let test (list, expected) =
+    let name =
+      Printf.sprintf "iteri over from [%s]"
+        (String.concat "; " (List.map string_of_int list))
+    in
+    let accum = ref [] in
+    let tested_f = Listext.iteri_right (fun i x -> accum := (i, x) :: !accum) in
+    let check () =
+      tested_f list ;
+      (* reverse the list so the lists in the specs reflect the order of
+         processing *)
+      let result = List.rev !accum in
+      Alcotest.(check @@ list @@ pair int int) name expected result
+    in
+    (name, `Quick, check)
+  in
+  let tests = List.map test specs in
+  ("iteri_right", tests)
+
+let test_take =
+  let specs =
+    [
+      ([], -1, [])
+    ; ([], 0, [])
+    ; ([], 1, [])
+    ; ([1; 2; 3], -1, [])
+    ; ([1; 2; 3], 0, [])
+    ; ([1; 2; 3], 1, [1])
+    ; ([1; 2; 3], 2, [1; 2])
+    ; ([1; 2; 3], 3, [1; 2; 3])
+    ; ([1; 2; 3], 4, [1; 2; 3])
+    ; ([1; 2; 3], 5, [1; 2; 3])
+    ]
+  in
+  let test (whole, number, expected) =
+    let name =
+      Printf.sprintf "take %i from [%s]" number
+        (String.concat "; " (List.map string_of_int whole))
+    in
+    test_list (Listext.take number) (name, whole, expected)
+  in
+  let tests = List.map test specs in
+  ("take", tests)
+
+let test_chop =
+  let specs =
+    [
+      ([], 0, ([], []))
+    ; ([0], 0, ([], [0]))
+    ; ([0], 1, ([0], []))
+    ; ([0; 1], 0, ([], [0; 1]))
+    ; ([0; 1], 1, ([0], [1]))
+    ; ([0; 1], 2, ([0; 1], []))
+    ]
+  in
+  let error_specs =
+    [([0], -1, Invalid_argument "chop"); ([0], 2, Invalid_argument "chop")]
+  in
+  let test (whole, number, expected) =
+    let name =
+      Printf.sprintf "chop [%s] with %i"
+        (String.concat "; " (List.map string_of_int whole))
+        number
+    in
+    test_chopped_list (Listext.chop number) (name, whole, expected)
+  in
+  let tests = List.map test specs in
+  let error_test (whole, number, error) =
+    let name =
+      Printf.sprintf "chop [%s] with %i fails"
+        (String.concat "; " (List.map string_of_int whole))
+        number
+    in
+    test_error
+      (fun ls () -> ignore (Listext.chop number ls))
+      (name, whole, error)
+  in
+  let error_tests = List.map error_test error_specs in
+  ("chop", tests @ error_tests)
+
+let test_sub =
+  let specs =
+    [
+      ([], 0, 0, [])
+    ; ([0], 0, 0, [])
+    ; ([0], 0, 1, [0])
+    ; ([0], 1, 1, [])
+    ; ([0; 1], 0, 0, [])
+    ; ([0; 1], 0, 1, [0])
+    ; ([0; 1], 0, 2, [0; 1])
+    ; ([0; 1], 1, 1, [])
+    ; ([0; 1], 1, 2, [1])
+    ; ([0; 1], 2, 2, [])
+    ]
+  in
+  let error_specs =
+    [
+      ([0], -1, 0, Invalid_argument "rev_chop")
+    ; ([0], 0, -1, Invalid_argument "rev_chop")
+    ; ([0; 1], 1, 0, Invalid_argument "rev_chop")
+    ]
+  in
+  let test (whole, from, until, expected) =
+    let name =
+      Printf.sprintf "sub [%s] from %i to %i"
+        (String.concat "; " (List.map string_of_int whole))
+        from until
+    in
+    test_list (Listext.sub from until) (name, whole, expected)
+  in
+  let tests = List.map test specs in
+  let error_test (whole, from, until, error) =
+    let name =
+      Printf.sprintf "sub [%s] from %i to %i fails"
+        (String.concat "; " (List.map string_of_int whole))
+        from until
+    in
+    test_error
+      (fun ls () -> ignore (Listext.sub from until ls))
+      (name, whole, error)
+  in
+  let error_tests = List.map error_test error_specs in
+  ("sub", tests @ error_tests)
+
+let test_safe_hd =
+  let specs = [([], None); ([0], Some 0); ([0; 1], Some 0)] in
+  let[@warning "-3"] test (list, expected) =
+    let name =
+      Printf.sprintf "safe_hd of [%s]"
+        (String.concat "; " (List.map string_of_int list))
+    in
+    test_option Listext.safe_hd (name, list, expected)
+  in
+  let tests = List.map test specs in
+  ("safe_hd", tests)
+
+let () =
+  Alcotest.run "Listext"
+    [test_iteri_right; test_take; test_chop; test_sub; test_safe_hd]

--- a/lib/xapi-stdext-std/listext_test.ml
+++ b/lib/xapi-stdext-std/listext_test.ml
@@ -84,6 +84,31 @@ let test_take =
   let tests = List.map test specs in
   ("take", tests)
 
+let test_drop =
+  let specs =
+    [
+      ([], -1, [])
+    ; ([], 0, [])
+    ; ([], 1, [])
+    ; ([1; 2; 3], -1, [1; 2; 3])
+    ; ([1; 2; 3], 0, [1; 2; 3])
+    ; ([1; 2; 3], 1, [2; 3])
+    ; ([1; 2; 3], 2, [3])
+    ; ([1; 2; 3], 3, [])
+    ; ([1; 2; 3], 4, [])
+    ; ([1; 2; 3], 5, [])
+    ]
+  in
+  let test (whole, number, expected) =
+    let name =
+      Printf.sprintf "drop %i from [%s]" number
+        (String.concat "; " (List.map string_of_int whole))
+    in
+    test_list (Listext.drop number) (name, whole, expected)
+  in
+  let tests = List.map test specs in
+  ("drop", tests)
+
 let test_chop =
   let specs =
     [
@@ -96,7 +121,10 @@ let test_chop =
     ]
   in
   let error_specs =
-    [([0], -1, Invalid_argument "chop"); ([0], 2, Invalid_argument "chop")]
+    [
+      ([0], -1, Invalid_argument "chop: index cannot be negative")
+    ; ([0], 2, Invalid_argument "chop: index not in list")
+    ]
   in
   let test (whole, number, expected) =
     let name =
@@ -124,22 +152,21 @@ let test_sub =
   let specs =
     [
       ([], 0, 0, [])
+    ; ([], 0, 1, [])
     ; ([0], 0, 0, [])
     ; ([0], 0, 1, [0])
     ; ([0], 1, 1, [])
+    ; ([0], 0, 2, [0])
     ; ([0; 1], 0, 0, [])
     ; ([0; 1], 0, 1, [0])
     ; ([0; 1], 0, 2, [0; 1])
     ; ([0; 1], 1, 1, [])
     ; ([0; 1], 1, 2, [1])
     ; ([0; 1], 2, 2, [])
-    ]
-  in
-  let error_specs =
-    [
-      ([0], -1, 0, Invalid_argument "rev_chop")
-    ; ([0], 0, -1, Invalid_argument "rev_chop")
-    ; ([0; 1], 1, 0, Invalid_argument "rev_chop")
+      (* test_cases below used to fail *) [@ocamlformat "disable"]
+    ; ([0], -1, 0, [])
+    ; ([0], 0, -1, [])
+    ; ([0; 1], 1, 0, [])
     ]
   in
   let test (whole, from, until, expected) =
@@ -151,18 +178,7 @@ let test_sub =
     test_list (Listext.sub from until) (name, whole, expected)
   in
   let tests = List.map test specs in
-  let error_test (whole, from, until, error) =
-    let name =
-      Printf.sprintf "sub [%s] from %i to %i fails"
-        (String.concat "; " (List.map string_of_int whole))
-        from until
-    in
-    test_error
-      (fun ls () -> ignore (Listext.sub from until ls))
-      (name, whole, error)
-  in
-  let error_tests = List.map error_test error_specs in
-  ("sub", tests @ error_tests)
+  ("sub", tests)
 
 let test_safe_hd =
   let specs = [([], None); ([0], Some 0); ([0; 1], Some 0)] in
@@ -178,4 +194,4 @@ let test_safe_hd =
 
 let () =
   Alcotest.run "Listext"
-    [test_iteri_right; test_take; test_chop; test_sub; test_safe_hd]
+    [test_iteri_right; test_take; test_drop; test_chop; test_sub; test_safe_hd]


### PR DESCRIPTION
This deprecates all functions in Listext that are present in Stdlib.List so it's bound to break some builds when integrating it into xs-opam.

Aside from that `sub` doesn't throw errors on invalid indeces, instead returning empty lists for empty ranges.

The used functions of Listext are the set functionality (`setify`, `set_equiv`, `set_difference`, `intersect`, `subset`), `assoc_default`, `replace_assoc`, `update_assoc`, `between` `take` and `chop`.

The set operations I think should be removed by changing the datatypes in xapi. I think the rest are reasonable to use. It seems that most of the listext module is not used and I'm tempted to deprecate the rest functions and remove them sooner rather than later.