### PR TITLE
unix: remove unused stdext-std dependency

### DIFF
--- a/lib/xapi-stdext-unix/dune
+++ b/lib/xapi-stdext-unix/dune
@@ -9,6 +9,5 @@
   (libraries
     fd-send-recv
     unix
-    xapi-stdext-pervasives
-    xapi-stdext-std)
+    xapi-stdext-pervasives)
 )

--- a/xapi-stdext-unix.opam
+++ b/xapi-stdext-unix.opam
@@ -14,7 +14,6 @@ depends: [
   "base-unix"
   "fd-send-recv" {>= "2.0.0"}
   "xapi-stdext-pervasives"
-  "xapi-stdext-std"
 ]
 synopsis:
   "A deprecated collection of utility functions - Unix module extensions"


### PR DESCRIPTION
Signed-off-by: Pau Ruiz Safont <pau.safont@citrix.com>