### PR TITLE
Drop deprecated functions from Listext, publish docs

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,47 @@
+name: Generate and upload docs
+
+on:
+  push:
+    branches: master
+
+jobs:
+  ocaml:
+    name: Ocaml docs
+    runs-on: ubuntu-20.04
+    env:
+      package: "xapi-stdext-date xapi-stdext-encodings xapi-stdext-pervasives xapi-stdext-std xapi-stdext-threads xapi-stdext-unix xapi-stdext-zerocheck"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Pull configuration from xs-opam
+        run: |
+          curl --fail --silent https://raw.githubusercontent.com/xapi-project/xs-opam/master/tools/xs-opam-ci.env | cut -f2 -d " " > .env
+
+      - name: Load environment file
+        id: dotenv
+        uses: falti/dotenv-action@v0.2.5
+
+      - name: Use ocaml
+        uses: ocaml/setup-ocaml@v1
+        with:
+          ocaml-version: ${{ steps.dotenv.outputs.ocaml_version_full }}
+          opam-repository: ${{ steps.dotenv.outputs.repository }}
+
+      - name: Install dependencies
+        run: |
+          opam pin add . --no-action
+          opam depext -u ${{ env.package }}
+          opam install ${{ env.package }} --deps-only --with-doc -v
+
+      - name: Docs
+        run: opam exec -- make doc
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: _build/default/_doc/_html/
+          publish_branch: gh-pages
+

--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@ Deprecated misc utility functions
 
 These utility functions are used by several other services. Much of this
 should be replaced with other libraries such as
-  * cohttp
-  * uri
-  * re
+  * Stdlib
+  * Bos
 
 Eventually this library should disappear.
+
+In the meantime documentation can be found at http://xapi-project.github.io/stdext/index.html

--- a/lib/xapi-stdext-std/dune
+++ b/lib/xapi-stdext-std/dune
@@ -2,7 +2,6 @@
   (public_name xapi-stdext-std)
   (name  xapi_stdext_std)
   (modules :standard \ xstringext_test listext_test)
-  (libraries uuidm)
 )
 (tests
   (names xstringext_test listext_test)

--- a/lib/xapi-stdext-std/listext.ml
+++ b/lib/xapi-stdext-std/listext.ml
@@ -13,7 +13,7 @@
  *)
 
 module List = struct
-  include List
+  open! List
 
   (** Turn a list into a set *)
   let rec setify = function

--- a/lib/xapi-stdext-std/listext.mli
+++ b/lib/xapi-stdext-std/listext.mli
@@ -18,119 +18,6 @@ module List : sig
 
   val set_equiv : 'a list -> 'a list -> bool
 
-  val length : 'a list -> int [@@deprecated "Use Stdlib.List instead"]
-
-  val hd : 'a list -> 'a [@@deprecated "Use Stdlib.List instead"]
-
-  val tl : 'a list -> 'a list [@@deprecated "Use Stdlib.List instead"]
-
-  val nth : 'a list -> int -> 'a [@@deprecated "Use Stdlib.List instead"]
-
-  val rev : 'a list -> 'a list [@@deprecated "Use Stdlib.List instead"]
-
-  val append : 'a list -> 'a list -> 'a list
-    [@@deprecated "Use Stdlib.List instead"]
-
-  val rev_append : 'a list -> 'a list -> 'a list
-    [@@deprecated "Use Stdlib.List instead"]
-
-  val concat : 'a list list -> 'a list [@@deprecated "Use Stdlib.List instead"]
-
-  val flatten : 'a list list -> 'a list [@@deprecated "Use Stdlib.List instead"]
-
-  val iter : ('a -> unit) -> 'a list -> unit
-    [@@deprecated "Use Stdlib.List instead"]
-
-  val map : ('a -> 'b) -> 'a list -> 'b list
-    [@@deprecated "Use Stdlib.List instead"]
-
-  val rev_map : ('a -> 'b) -> 'a list -> 'b list
-    [@@deprecated "Use Stdlib.List instead"]
-
-  val fold_left : ('a -> 'b -> 'a) -> 'a -> 'b list -> 'a
-    [@@deprecated "Use Stdlib.List instead"]
-
-  val fold_right : ('a -> 'b -> 'b) -> 'a list -> 'b -> 'b
-    [@@deprecated "Use Stdlib.List instead"]
-
-  val iter2 : ('a -> 'b -> unit) -> 'a list -> 'b list -> unit
-    [@@deprecated "Use Stdlib.List instead"]
-
-  val map2 : ('a -> 'b -> 'c) -> 'a list -> 'b list -> 'c list
-    [@@deprecated "Use Stdlib.List instead"]
-
-  val rev_map2 : ('a -> 'b -> 'c) -> 'a list -> 'b list -> 'c list
-    [@@deprecated "Use Stdlib.List instead"]
-
-  val fold_left2 : ('a -> 'b -> 'c -> 'a) -> 'a -> 'b list -> 'c list -> 'a
-    [@@deprecated "Use Stdlib.List instead"]
-
-  val fold_right2 : ('a -> 'b -> 'c -> 'c) -> 'a list -> 'b list -> 'c -> 'c
-    [@@deprecated "Use Stdlib.List instead"]
-
-  val for_all : ('a -> bool) -> 'a list -> bool
-    [@@deprecated "Use Stdlib.List instead"]
-
-  val exists : ('a -> bool) -> 'a list -> bool
-    [@@deprecated "Use Stdlib.List instead"]
-
-  val for_all2 : ('a -> 'b -> bool) -> 'a list -> 'b list -> bool
-    [@@deprecated "Use Stdlib.List instead"]
-
-  val exists2 : ('a -> 'b -> bool) -> 'a list -> 'b list -> bool
-    [@@deprecated "Use Stdlib.List instead"]
-
-  val mem : 'a -> 'a list -> bool [@@deprecated "Use Stdlib.List instead"]
-
-  val memq : 'a -> 'a list -> bool [@@deprecated "Use Stdlib.List instead"]
-
-  val find : ('a -> bool) -> 'a list -> 'a
-    [@@deprecated "Use Stdlib.List instead"]
-
-  val filter : ('a -> bool) -> 'a list -> 'a list
-    [@@deprecated "Use Stdlib.List instead"]
-
-  val find_all : ('a -> bool) -> 'a list -> 'a list
-    [@@deprecated "Use Stdlib.List instead"]
-
-  val partition : ('a -> bool) -> 'a list -> 'a list * 'a list
-    [@@deprecated "Use Stdlib.List instead"]
-
-  val assoc : 'a -> ('a * 'b) list -> 'b
-    [@@deprecated "Use Stdlib.List instead"]
-
-  val assq : 'a -> ('a * 'b) list -> 'b [@@deprecated "Use Stdlib.List instead"]
-
-  val mem_assoc : 'a -> ('a * 'b) list -> bool
-    [@@deprecated "Use Stdlib.List instead"]
-
-  val mem_assq : 'a -> ('a * 'b) list -> bool
-    [@@deprecated "Use Stdlib.List instead"]
-
-  val remove_assoc : 'a -> ('a * 'b) list -> ('a * 'b) list
-    [@@deprecated "Use Stdlib.List instead"]
-
-  val remove_assq : 'a -> ('a * 'b) list -> ('a * 'b) list
-    [@@deprecated "Use Stdlib.List instead"]
-
-  val split : ('a * 'b) list -> 'a list * 'b list
-    [@@deprecated "Use Stdlib.List instead"]
-
-  val combine : 'a list -> 'b list -> ('a * 'b) list
-    [@@deprecated "Use Stdlib.List instead"]
-
-  val sort : ('a -> 'a -> int) -> 'a list -> 'a list
-    [@@deprecated "Use Stdlib.List instead"]
-
-  val stable_sort : ('a -> 'a -> int) -> 'a list -> 'a list
-    [@@deprecated "Use Stdlib.List instead"]
-
-  val fast_sort : ('a -> 'a -> int) -> 'a list -> 'a list
-    [@@deprecated "Use Stdlib.List instead"]
-
-  val merge : ('a -> 'a -> int) -> 'a list -> 'a list -> 'a list
-    [@@deprecated "Use Stdlib.List instead"]
-
   val inv_assoc : 'a -> ('b * 'a) list -> 'b
   (** Perform a lookup on an association list of (value, key) pairs. *)
 
@@ -142,14 +29,6 @@ module List : sig
 
   val position : ('a -> bool) -> 'a list -> int list
   (** Find the indices of all elements matching the given predicate. *)
-
-  val mapi : (int -> 'a -> 'b) -> 'a list -> 'b list
-    [@@deprecated "Use Stdlib.List instead"]
-  (** Map the given function over a list, supplying the integer
-      	    index as well as the element value. *)
-
-  val iteri : (int -> 'a -> unit) -> 'a list -> unit
-    [@@deprecated "Use Stdlib.List instead"]
 
   val iteri_right : (int -> 'a -> unit) -> 'a list -> unit
 
@@ -184,9 +63,6 @@ module List : sig
   val remove : int -> 'a list -> 'a list
   (** Remove the element at the given index. *)
 
-  (** Extract the element at the given index, returning the element and the
-      		list without that element. *)
-
   val insert : int -> 'a -> 'a list -> 'a list
   (** Insert the given element at the given index. *)
 
@@ -198,7 +74,7 @@ module List : sig
 
   val between : 'a -> 'a list -> 'a list
   (** Insert the element [e] between every pair of adjacent elements in the
-      	    given list. *)
+      given list. *)
 
   val between_tr : 'a -> 'a list -> 'a list
   (** Tail-recursive [between]. *)
@@ -208,7 +84,7 @@ module List : sig
 
   val distribute : 'a -> 'a list -> 'a list list
   (** Distribute the given element over the given list, returning a list of
-      	    lists with the new element in each position. *)
+      lists with the new element in each position. *)
 
   val permute : 'a list -> 'a list list
   (** Generate all permutations of the given list. *)
@@ -232,17 +108,9 @@ module List : sig
     -> 'h
   (** Compute the inner product of two lists. *)
 
-  val filter_map : ('a -> 'b option) -> 'a list -> 'b list
-    [@@deprecated "Use Stdlib.List instead"]
-  (** Applies a function f that generates optional values, to each
-      	    of the items in a list A [a1; ...; am], generating a new list of
-      	    non-optional values B [b1; ...; bn], with m >= n. For each value
-      	    a in list A, list B contains a corresponding value b if and only
-      	    if the application of (f a) results in Some b.  *)
-
   val is_sorted : ('a -> 'a -> int) -> 'a list -> bool
   (** Returns true if and only if the given list is in sorted order
-      	    according to the given comparison function.  *)
+      according to the given comparison function.  *)
 
   val intersect : 'a list -> 'a list -> 'a list
   (** Returns the intersection of two lists. *)
@@ -252,19 +120,16 @@ module List : sig
 
   val assoc_default : 'a -> ('a * 'b) list -> 'b -> 'b
   (** Act as List.assoc, but return the given default value if the
-      	    key is not in the list. *)
+      key is not in the list. *)
 
   val map_assoc_with_key :
     ('k -> 'v1 -> 'v2) -> ('k * 'v1) list -> ('k * 'v2) list
   (** [map_assoc_with_key op al] transforms every value in [al] based on the
-      	    key and the value using [op]. *)
-
-  (* Like Lisp cons*)
-  val cons : 'a -> 'a list -> 'a list [@@deprecated "Use Stdlib.List instead"]
+      key and the value using [op]. *)
 
   val take : int -> 'a list -> 'a list
   (** [take n list] returns the first [n] elements of [list] (or less if list
-      	    is shorter).*)
+      is shorter).*)
 
   val drop : int -> 'a list -> 'a list
   (** [drop n list] returns the list without the first [n] elements of [list]
@@ -272,19 +137,16 @@ module List : sig
 
   val tails : 'a list -> 'a list list
 
-  val safe_hd : 'a list -> 'a option
-    [@@deprecated "Use List.nth_opt list 0 instead"]
-
   val replace_assoc : 'a -> 'b -> ('a * 'b) list -> ('a * 'b) list
   (** Replace the value belonging to a key in an association list. Adds the key/value pair
-      	 *  if it does not yet exist in the list. If the same key occurs multiple time in the original
-      	 *  list, all occurances are removed and replaced by a single new key/value pair.
-      	 *  This function is useful is the assoc list is used as a lightweight map/hashtable/dictonary. *)
+      if it does not yet exist in the list. If the same key occurs multiple time in the original
+      list, all occurances are removed and replaced by a single new key/value pair.
+      This function is useful is the assoc list is used as a lightweight map/hashtable/dictonary. *)
 
   val update_assoc : ('a * 'b) list -> ('a * 'b) list -> ('a * 'b) list
   (** Includes everything from [update] and all key/value pairs from [existing] for
-      	 *  which the key does not exist in [update]. In other words, it is like [replace_assoc]
-      	 *  but then given a whole assoc list of updates rather than a single key/value pair. *)
+      which the key does not exist in [update]. In other words, it is like [replace_assoc]
+      but then given a whole assoc list of updates rather than a single key/value pair. *)
 
   val make_assoc : ('a -> 'b) -> 'a list -> ('a * 'b) list
 
@@ -293,10 +155,10 @@ module List : sig
 
   val restrict_with_default : 'v -> 'k list -> ('k * 'v) list -> ('k * 'v) list
   (** [restrict_with_default default keys al] makes a new association map
-      	    from [keys] to previous values for [keys] in [al]. If a key is not found
-      	    in [al], the [default] is used. *)
+      from [keys] to previous values for [keys] in [al]. If a key is not found
+      in [al], the [default] is used. *)
 
   val range : int -> int -> int list
   (** range lower upper = [lower; lower + 1; ...; upper - 1]
-      	    Returns the empty list if lower >= upper. *)
+      Returns the empty list if lower >= upper. *)
 end

--- a/lib/xapi-stdext-std/listext.mli
+++ b/lib/xapi-stdext-std/listext.mli
@@ -12,17 +12,33 @@
  * GNU Lesser General Public License for more details.
  *)
 module List : sig
-  val setify : 'a list -> 'a list
+  (** {1 Comparison} *)
 
-  val subset : 'a list -> 'a list -> bool
+  val is_sorted : ('a -> 'a -> int) -> 'a list -> bool
+  (** [is_sorted cmp l] returns whether [l] is sorted according to [cmp]. *)
 
-  val set_equiv : 'a list -> 'a list -> bool
+  (** {1 Iterators} *)
 
-  val inv_assoc : 'a -> ('b * 'a) list -> 'b
-  (** Perform a lookup on an association list of (value, key) pairs. *)
+  val take : int -> 'a list -> 'a list
+  (** [take n list] returns the first [n] elements of [list] (or less if list
+      is shorter).*)
+
+  val drop : int -> 'a list -> 'a list
+  (** [drop n list] returns the list without the first [n] elements of [list]
+      (or [] if list is shorter). *)
+
+  val rev_mapi : (int -> 'a -> 'b) -> 'a list -> 'b list
+  (** [rev_map f l] gives the same result as {!Stdlib.List.rev}[ (]
+      {!Stdlib.List.mapi}[ f l)], but is tail-recursive and more efficient. *)
 
   val map_tr : ('a -> 'b) -> 'a list -> 'b list
-  (** A tail-recursive map. *)
+  (** [map_tr f l] is {!Stdlib.List.rev}[ (]{!Stdlib.List.rev_map}[ f l)]. *)
+
+  val mapi_tr : (int -> 'a -> 'b) -> 'a list -> 'b list
+  (** [mapi_tr f l] is {!Stdlib.List.rev}[ (]{!rev_mapi}[ f l)]. *)
+
+  val unbox_list : 'a option list -> 'a list
+  (** Unbox all values from the option list. *)
 
   val count : ('a -> bool) -> 'a list -> int
   (** Count the number of list elements matching the given predicate. *)
@@ -31,12 +47,9 @@ module List : sig
   (** Find the indices of all elements matching the given predicate. *)
 
   val iteri_right : (int -> 'a -> unit) -> 'a list -> unit
+  (** [iteri_right f l] is {!Stdlib.List.iteri}[ f (]{!Stdlib.List.rev}[ l)] *)
 
-  val rev_mapi : (int -> 'a -> 'b) -> 'a list -> 'b list
-  (** Map the given function over a list in reverse order. *)
-
-  val mapi_tr : (int -> 'a -> 'b) -> 'a list -> 'b list
-  (** Tail-recursive [mapi]. *)
+  (** {1 Using indices to manipulate lists} *)
 
   val chop : int -> 'a list -> 'a list * 'a list
   (** [chop k l] splits [l] at index [k] to return a pair of lists. Raises
@@ -48,11 +61,11 @@ module List : sig
       greater than the length of [l]. *)
 
   val chop_tr : int -> 'a list -> 'a list * 'a list
-  (** Tail-recursive [chop]. *)
+  (** Tail-recursive {!chop}. *)
 
   val dice : int -> 'a list -> 'a list list
   (** [dice k l] splits [l] into lists with [k] elements each. Raises
-      invalid_arg if [List.length l] is not divisible by [k]. *)
+      {!Invalid_arg} if [List.length l] is not divisible by [k]. *)
 
   val sub : int -> int -> 'a list -> 'a list
   (** [sub from to l] returns the sub-list of [l] that starts at index [from]
@@ -72,70 +85,13 @@ module List : sig
   val morph : int -> ('a -> 'a) -> 'a list -> 'a list
   (** Apply the given function to the element at the given index. *)
 
-  val between : 'a -> 'a list -> 'a list
-  (** Insert the element [e] between every pair of adjacent elements in the
-      given list. *)
+  (** {1 Association Lists} *)
 
-  val between_tr : 'a -> 'a list -> 'a list
-  (** Tail-recursive [between]. *)
-
-  val randomize : 'a list -> 'a list
-  (** Generate a random permutation of the given list. *)
-
-  val distribute : 'a -> 'a list -> 'a list list
-  (** Distribute the given element over the given list, returning a list of
-      lists with the new element in each position. *)
-
-  val permute : 'a list -> 'a list list
-  (** Generate all permutations of the given list. *)
-
-  val rle_eq : ('a -> 'a -> bool) -> 'a list -> ('a * int) list
-  (** Run-length encode the given list using the given equality function. *)
-
-  val rle : 'a list -> ('a * int) list
-  (** Run-length encode the given list using built-in equality. *)
-
-  val unrle : (int * 'a) list -> 'a list
-  (** Decode a run-length encoded list. *)
-
-  val inner :
-       (('a -> 'b -> 'c -> 'd) -> 'e -> 'f -> 'g -> 'h)
-    -> 'e
-    -> ('b -> 'c -> 'i)
-    -> 'f
-    -> 'g
-    -> ('a -> 'i -> 'd)
-    -> 'h
-  (** Compute the inner product of two lists. *)
-
-  val is_sorted : ('a -> 'a -> int) -> 'a list -> bool
-  (** Returns true if and only if the given list is in sorted order
-      according to the given comparison function.  *)
-
-  val intersect : 'a list -> 'a list -> 'a list
-  (** Returns the intersection of two lists. *)
-
-  val set_difference : 'a list -> 'a list -> 'a list
-  (** Returns the set difference of two lists *)
+  val make_assoc : ('a -> 'b) -> 'a list -> ('a * 'b) list
 
   val assoc_default : 'a -> ('a * 'b) list -> 'b -> 'b
   (** Act as List.assoc, but return the given default value if the
       key is not in the list. *)
-
-  val map_assoc_with_key :
-    ('k -> 'v1 -> 'v2) -> ('k * 'v1) list -> ('k * 'v2) list
-  (** [map_assoc_with_key op al] transforms every value in [al] based on the
-      key and the value using [op]. *)
-
-  val take : int -> 'a list -> 'a list
-  (** [take n list] returns the first [n] elements of [list] (or less if list
-      is shorter).*)
-
-  val drop : int -> 'a list -> 'a list
-  (** [drop n list] returns the list without the first [n] elements of [list]
-      (or [] if list is shorter). *)
-
-  val tails : 'a list -> 'a list list
 
   val replace_assoc : 'a -> 'b -> ('a * 'b) list -> ('a * 'b) list
   (** Replace the value belonging to a key in an association list. Adds the key/value pair
@@ -148,17 +104,88 @@ module List : sig
       which the key does not exist in [update]. In other words, it is like [replace_assoc]
       but then given a whole assoc list of updates rather than a single key/value pair. *)
 
-  val make_assoc : ('a -> 'b) -> 'a list -> ('a * 'b) list
+  val map_assoc_with_key :
+    ('k -> 'v1 -> 'v2) -> ('k * 'v1) list -> ('k * 'v2) list
+  (** [map_assoc_with_key op al] transforms every value in [al] based on the
+      key and the value using [op]. *)
 
-  val unbox_list : 'a option list -> 'a list
-  (** Unbox all values from the option list. *)
+  val inv_assoc : 'a -> ('b * 'a) list -> 'b
+  (** Perform a lookup on an association list of (value, key) pairs. *)
 
   val restrict_with_default : 'v -> 'k list -> ('k * 'v) list -> ('k * 'v) list
   (** [restrict_with_default default keys al] makes a new association map
       from [keys] to previous values for [keys] in [al]. If a key is not found
       in [al], the [default] is used. *)
 
+  (** {1 Run-length encoded lists}
+      There are no known users of these functions. *)
+
+  val rle : 'a list -> ('a * int) list
+    [@@deprecated
+      "No known users, consider creating a proper datatype, this kind of list \
+       might be confused with association lists"]
+  (** Run-length encodes the given list using polimorphic equality *)
+
+  val unrle : (int * 'a) list -> 'a list
+    [@@deprecated "No known users"]
+  (** Decode a run-length encoded list. *)
+
+  val rle_eq : ('a -> 'a -> bool) -> 'a list -> ('a * int) list
+    [@@deprecated "No known users"]
+  (** [rle_eq eq l] run-length encodes [l] using [eq] *)
+
+  (** {1 Generative functions}
+      These are usually useful for coding challenges like Advent of Code.*)
+
   val range : int -> int -> int list
   (** range lower upper = [lower; lower + 1; ...; upper - 1]
-      Returns the empty list if lower >= upper. *)
+      Returns the empty list if lower >= upper.
+      Consider building an {!Stdlib.Seq}, it's more flexible *)
+
+  val between : 'a -> 'a list -> 'a list
+  (** [between e l] Intersperses [e] between elements of [l]. *)
+
+  val between_tr : 'a -> 'a list -> 'a list
+  (** Tail-recursive {!between}. *)
+
+  val randomize : 'a list -> 'a list [@@deprecated "Not used"]
+  (** Generate a random permutation of the given list. *)
+
+  val distribute : 'a -> 'a list -> 'a list list [@@deprecated "Not used"]
+  (** Distribute the given element over the given list, returning a list of
+      lists with the new element in each position. *)
+
+  val permute : 'a list -> 'a list list [@@deprecated "Not used"]
+  (** Generate all permutations of the given list. *)
+
+  val inner :
+       (('a -> 'b -> 'c -> 'd) -> 'e -> 'f -> 'g -> 'h)
+    -> 'e
+    -> ('b -> 'c -> 'i)
+    -> 'f
+    -> 'g
+    -> ('a -> 'i -> 'd)
+    -> 'h
+  (** Compute the inner product of two lists. *)
+
+  val tails : 'a list -> 'a list list
+
+  (** {1 Lists as sets, avoid}
+      Please use Set.Make instead, these functions have quadratic costs! *)
+
+  val setify : 'a list -> 'a list
+  (** [setify a] removes all duplicates from [a] while maintaining order.
+      Please use [List.sort_uniq] instead to deduplicate lists if possible *)
+
+  val subset : 'a list -> 'a list -> bool
+  (** [subset a b] returns whether all elements in [b] can be found in [a]*)
+
+  val set_equiv : 'a list -> 'a list -> bool
+
+  val set_difference : 'a list -> 'a list -> 'a list
+  (** Returns the set difference of two lists *)
+
+  val intersect : 'a list -> 'a list -> 'a list
+  (** Returns the intersection of two lists. *)
+
 end

--- a/lib/xapi-stdext-std/listext_test.ml
+++ b/lib/xapi-stdext-std/listext_test.ml
@@ -180,18 +180,6 @@ let test_sub =
   let tests = List.map test specs in
   ("sub", tests)
 
-let test_safe_hd =
-  let specs = [([], None); ([0], Some 0); ([0; 1], Some 0)] in
-  let[@warning "-3"] test (list, expected) =
-    let name =
-      Printf.sprintf "safe_hd of [%s]"
-        (String.concat "; " (List.map string_of_int list))
-    in
-    test_option Listext.safe_hd (name, list, expected)
-  in
-  let tests = List.map test specs in
-  ("safe_hd", tests)
-
 let () =
   Alcotest.run "Listext"
-    [test_iteri_right; test_take; test_drop; test_chop; test_sub; test_safe_hd]
+    [test_iteri_right; test_take; test_drop; test_chop; test_sub]

--- a/lib/xapi-stdext-threads/semaphore.mli
+++ b/lib/xapi-stdext-threads/semaphore.mli
@@ -17,21 +17,21 @@ type t
 exception Inconsistent_state of string
 
 (** [create n] create a semaphore with initial value [n] (a positive integer).
-    Raise {Invalid_argument} if [n] <= 0 *)
+    Raise {!Invalid_argument} if [n] <= 0 *)
 val create : int -> t
 
 (** [acquire k s] block until the semaphore value is >= [k] (a positive integer),
     then atomically decrement the semaphore value by [k].
-    Raise {Invalid_argument} if [k] <= 0 *)
+    Raise {!Invalid_argument} if [k] <= 0 *)
 val acquire : t -> int -> unit
 
 (** [release k s] atomically increment the semaphore value by [k] (a positive
     integer).
-    Raise {Invalid_argument} if [k] <= 0 *)
+    Raise {!Invalid_argument} if [k] <= 0 *)
 val release : t -> int -> unit
 
-(** [execute_with_weight s k f] {acquire} the semaphore with [k],
-    then run [f ()], and finally {release} the semaphore with the same value [k]
+(** [execute_with_weight s k f] {!acquire} the semaphore with [k],
+    then run [f ()], and finally {!release} the semaphore with the same value [k]
     (even in case of failure in the execution of [f]).
     Return the value of [f ()] or re-raise the exception if any. *)
 val execute_with_weight : t -> int -> (unit -> 'a) -> 'a

--- a/xapi-stdext-date.opam
+++ b/xapi-stdext-date.opam
@@ -8,16 +8,18 @@ tags: [ "org:xapi-project" ]
 
 build:  [
   [ "dune" "build" "-p" name "-j" jobs ]
-  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+  ["dune" "build" "-p" name "-j" jobs "@doc"] {with-doc}
+  ["dune" "build" "-p" name "-j" jobs "@runtest"] {with-test}
 ]
 
 depends: [
   "ocaml"
-  "dune" {build}
+  "dune" {>= "1.11"}
   "alcotest" {with-test}
   "astring"
   "base-unix"
   "ptime"
+  "odoc" {with-doc}
 ]
 synopsis: "A deprecated collection of utility functions - Date module"
 description: """

--- a/xapi-stdext-encodings.opam
+++ b/xapi-stdext-encodings.opam
@@ -8,13 +8,15 @@ tags: [ "org:xapi-project" ]
 
 build:  [
   [ "dune" "build" "-p" name "-j" jobs ]
-  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+  ["dune" "build" "-p" name "-j" jobs "@doc"] {with-doc}
+  ["dune" "build" "-p" name "-j" jobs "@runtest"] {with-test}
 ]
 
 depends: [
   "ocaml"
-  "dune" {build}
+  "dune" {>= "1.11"}
   "alcotest" {with-test}
+  "odoc" {with-doc}
 ]
 synopsis: "A deprecated collection of utility functions - Encodings module"
 description: """

--- a/xapi-stdext-pervasives.opam
+++ b/xapi-stdext-pervasives.opam
@@ -6,12 +6,16 @@ dev-repo: "git://github.com/xapi-project/stdext.git"
 homepage: "https://xapi-project.github.io/"
 tags: [ "org:xapi-project" ]
 
-build:  [[ "dune" "build" "-p" name "-j" jobs ]]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "-p" name "-j" jobs "@doc"] {with-doc}
+]
 
 depends: [
   "ocaml"
-  "dune" {build}
+  "dune" {>= "1.11"}
   "logs"
+  "odoc" {with-doc}
   "xapi-backtrace"
 ]
 synopsis:

--- a/xapi-stdext-std.opam
+++ b/xapi-stdext-std.opam
@@ -8,14 +8,15 @@ tags: [ "org:xapi-project" ]
 
 build:  [
   [ "dune" "build" "-p" name "-j" jobs ]
+  ["dune" "build" "-p" name "-j" jobs "@doc"] {with-doc}
   [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
 ]
 
 depends: [
   "ocaml"
-  "dune" {build}
-  "uuidm"
+  "dune" {>= "1.11"}
   "alcotest" {with-test}
+  "odoc" {with-doc}
 ]
 synopsis:
   "A deprecated collection of utility functions - Standard library extensions"

--- a/xapi-stdext-threads.opam
+++ b/xapi-stdext-threads.opam
@@ -6,13 +6,17 @@ dev-repo: "git://github.com/xapi-project/stdext.git"
 homepage: "https://xapi-project.github.io/"
 tags: [ "org:xapi-project" ]
 
-build:  [[ "dune" "build" "-p" name "-j" jobs ]]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "-p" name "-j" jobs "@doc"] {with-doc}
+]
 
 depends: [
   "ocaml"
-  "dune" {build}
+  "dune" {>= "1.11"}
   "base-threads"
   "base-unix"
+  "odoc" {with-doc}
   "xapi-stdext-pervasives"
 ]
 synopsis:

--- a/xapi-stdext-unix.opam
+++ b/xapi-stdext-unix.opam
@@ -6,11 +6,14 @@ dev-repo: "git://github.com/xapi-project/stdext.git"
 homepage: "https://xapi-project.github.io/"
 tags: [ "org:xapi-project" ]
 
-build:  [[ "dune" "build" "-p" name "-j" jobs ]]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "-p" name "-j" jobs "@doc"] {with-doc}
+]
 
 depends: [
   "ocaml"
-  "dune" {build}
+  "dune" {>= "1.11"}
   "base-unix"
   "fd-send-recv" {>= "2.0.0"}
   "xapi-stdext-pervasives"

--- a/xapi-stdext-zerocheck.opam
+++ b/xapi-stdext-zerocheck.opam
@@ -6,11 +6,14 @@ dev-repo: "git://github.com/xapi-project/stdext.git"
 homepage: "https://xapi-project.github.io/"
 tags: [ "org:xapi-project" ]
 
-build:  [[ "dune" "build" "-p" name "-j" jobs ]]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "-p" name "-j" jobs "@doc"] {with-doc}
+]
 
 depends: [
-  "ocaml"
-  "dune" {build}
+  "dune" {>= "1.11"}
+  "odoc" {with-doc}
 ]
 synopsis: "A deprecated collection of utility functions - Zerocheck module"
 description: """


### PR DESCRIPTION
The deprecation warning from listext have all cleaned up, so removing these is safe.

The docs are published to https://xapi-project.github.io/stdext/ and the resulting List documentation can be read at https://xapi-project.github.io/stdext/xapi-stdext-std/Xapi_stdext_std/Listext/List/index.html  

Opam metadata for all packages was revamped to able to build documentation.