### PR TITLE
Date: allow conversions from ptime.t, and unix time

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## 4.20.0 (17-Nov-2022)
+ - date: consolidate the types into a single t
+ - date: add conversion functions that have semantic meaning, the previous functions containing 'float' and 'string' will be deprecated in a future release.
+
 ## v4.19.0 (17-Jun-2022)
  - maintenance: give a name to the project
  - threads: Remove all the modules except Mutex

--- a/lib/xapi-stdext-date/date.ml
+++ b/lib/xapi-stdext-date/date.ml
@@ -30,12 +30,10 @@ let months =
 
 let days = [|"Sun"; "Mon"; "Tue"; "Wed"; "Thu"; "Fri"; "Sat"|]
 
-(* ==== ISO8601/RFC3339 ==== *)
-
 type print_timezone = Empty | TZ of string
 
 (* we must store the print_type with iso8601 to handle the case where the local time zone is UTC *)
-type iso8601 = Ptime.date * Ptime.time * print_timezone
+type t = Ptime.date * Ptime.time * print_timezone
 
 let utc = TZ "Z"
 
@@ -73,13 +71,13 @@ let of_iso8601 x =
   let rfc3339, print_timezone = best_effort_iso8601_to_rfc3339 x in
   match Ptime.of_rfc3339 rfc3339 |> Ptime.rfc3339_error_to_msg with
   | Error _ ->
-      invalid_arg (Printf.sprintf "date.ml:of_string: %s" x)
+      invalid_arg (Printf.sprintf "%s: %s" __FUNCTION__ x)
   | Ok (t, tz, _) -> (
     match tz with
     | None | Some 0 ->
         Ptime.to_date_time t |> of_dt print_timezone
     | Some _ ->
-        invalid_arg (Printf.sprintf "date.ml:of_string: %s" x)
+        invalid_arg (Printf.sprintf "%s: %s" __FUNCTION__ x)
   )
 
 let to_rfc3339 ((y, mon, d), ((h, min, s), _), print_type) =
@@ -111,7 +109,7 @@ let to_ptime_t t =
   | None ->
       let _, (_, offset), _ = t in
       invalid_arg
-        (Printf.sprintf "date.ml:to_t: dt='%s', offset='%i' is invalid"
+        (Printf.sprintf "%s: dt='%s', offset='%i' is invalid" __FUNCTION__
            (to_rfc3339 t) offset
         )
 
@@ -134,9 +132,8 @@ let _localtime current_tz_offset t =
   let _, (_, localtime_offset), _ = localtime in
   if localtime_offset <> tz_offset_s then
     invalid_arg
-      (Printf.sprintf
-         "date.ml:_localtime: offsets don't match. offset='%i', t='%s'"
-         tz_offset_s (Ptime.to_rfc3339 t)
+      (Printf.sprintf "%s: offsets don't match. offset='%i', t='%s'"
+         __FUNCTION__ tz_offset_s (Ptime.to_rfc3339 t)
       ) ;
   localtime
 
@@ -168,4 +165,6 @@ let rfc822_of_float = of_unix_time
 
 let rfc822_to_string = to_rfc822
 
-type rfc822 = iso8601
+type iso8601 = t
+
+type rfc822 = t

--- a/lib/xapi-stdext-date/date.ml
+++ b/lib/xapi-stdext-date/date.ml
@@ -15,15 +15,28 @@
 (* ==== RFC822 ==== *)
 type rfc822 = string
 
-let months = [| "Jan"; "Feb"; "Mar"; "Apr"; "May"; "Jun";
-                "Jul"; "Aug"; "Sep"; "Oct"; "Nov"; "Dec" |]
-let days = [| "Sun"; "Mon"; "Tue"; "Wed"; "Thu"; "Fri"; "Sat" |]
+let months =
+  [|
+     "Jan"
+   ; "Feb"
+   ; "Mar"
+   ; "Apr"
+   ; "May"
+   ; "Jun"
+   ; "Jul"
+   ; "Aug"
+   ; "Sep"
+   ; "Oct"
+   ; "Nov"
+   ; "Dec"
+  |]
+
+let days = [|"Sun"; "Mon"; "Tue"; "Wed"; "Thu"; "Fri"; "Sat"|]
 
 let rfc822_of_float x =
   let time = Unix.gmtime x in
-  Printf.sprintf "%s, %d %s %d %02d:%02d:%02d GMT"
-    days.(time.Unix.tm_wday) time.Unix.tm_mday
-    months.(time.Unix.tm_mon) (time.Unix.tm_year+1900)
+  Printf.sprintf "%s, %d %s %d %02d:%02d:%02d GMT" days.(time.Unix.tm_wday)
+    time.Unix.tm_mday months.(time.Unix.tm_mon) (time.Unix.tm_year + 1900)
     time.Unix.tm_hour time.Unix.tm_min time.Unix.tm_sec
 
 let rfc822_to_string x = x
@@ -31,12 +44,16 @@ let rfc822_to_string x = x
 (* ==== ISO8601/RFC3339 ==== *)
 
 type print_timezone = Empty | TZ of string
+
 (* we must store the print_type with iso8601 to handle the case where the local time zone is UTC *)
 type iso8601 = Ptime.date * Ptime.time * print_timezone
 
 let utc = TZ "Z"
 
-let of_dt print_type dt = let (date, time) = dt in (date, time, print_type)
+let of_dt print_type dt =
+  let date, time = dt in
+  (date, time, print_type)
+
 let to_dt (date, time, _) = (date, time)
 
 let best_effort_iso8601_to_rfc3339 x =
@@ -44,44 +61,55 @@ let best_effort_iso8601_to_rfc3339 x =
    * (b) add UTC tz if no tz provided *)
   let x =
     try
-      Scanf.sscanf x "%04d%02d%02dT%s"
-        (fun y mon d rest ->
-          Printf.sprintf "%04d-%02d-%02dT%s" y mon d rest)
-    with _ ->
-      x
+      Scanf.sscanf x "%04d%02d%02dT%s" (fun y mon d rest ->
+          Printf.sprintf "%04d-%02d-%02dT%s" y mon d rest
+      )
+    with _ -> x
   in
   let tz =
     try
-      Scanf.sscanf x "%04d-%02d-%02dT%02d:%02d:%02d%s"
-        (fun _ _ _ _ _ _ tz -> Some tz)
+      Scanf.sscanf x "%04d-%02d-%02dT%02d:%02d:%02d%s" (fun _ _ _ _ _ _ tz ->
+          Some tz
+      )
     with _ -> None
   in
   match tz with
   | None | Some "" ->
-    (* the caller didn't specify a tz. we must try to add one so that ptime can at least attempt to parse *)
-    (Printf.sprintf "%sZ" x, Empty)
-  | Some tz  ->
-    (x, TZ tz)
+      (* the caller didn't specify a tz. we must try to add one so that ptime can at least attempt to parse *)
+      (Printf.sprintf "%sZ" x, Empty)
+  | Some tz ->
+      (x, TZ tz)
 
 let of_iso8601 x =
-  let (rfc3339, print_timezone) = best_effort_iso8601_to_rfc3339 x in
+  let rfc3339, print_timezone = best_effort_iso8601_to_rfc3339 x in
   match Ptime.of_rfc3339 rfc3339 |> Ptime.rfc3339_error_to_msg with
-  | Error (`Msg e) -> invalid_arg (Printf.sprintf "date.ml:of_string: %s" x)
-  | Ok (t, tz, _)  -> match tz with
-                      | None | Some 0 -> Ptime.to_date_time t |> of_dt print_timezone
-                      | Some _        -> invalid_arg (Printf.sprintf "date.ml:of_string: %s" x)
+  | Error _ ->
+      invalid_arg (Printf.sprintf "date.ml:of_string: %s" x)
+  | Ok (t, tz, _) -> (
+    match tz with
+    | None | Some 0 ->
+        Ptime.to_date_time t |> of_dt print_timezone
+    | Some _ ->
+        invalid_arg (Printf.sprintf "date.ml:of_string: %s" x)
+  )
 
-let to_rfc3339 ((y,mon,d), ((h,min,s), _), print_type) =
+let to_rfc3339 ((y, mon, d), ((h, min, s), _), print_type) =
   match print_type with
-  | TZ tz -> Printf.sprintf "%04i%02i%02iT%02i:%02i:%02i%s" y mon d h min s tz
-  | Empty -> Printf.sprintf "%04i%02i%02iT%02i:%02i:%02i" y mon d h min s
+  | TZ tz ->
+      Printf.sprintf "%04i%02i%02iT%02i:%02i:%02i%s" y mon d h min s tz
+  | Empty ->
+      Printf.sprintf "%04i%02i%02iT%02i:%02i:%02i" y mon d h min s
 
 let to_ptime_t t =
   match to_dt t |> Ptime.of_date_time with
-  | Some t -> t
+  | Some t ->
+      t
   | None ->
-    let (_, (_, offset), _) = t in
-    invalid_arg (Printf.sprintf "date.ml:to_t: dt='%s', offset='%i' is invalid" (to_rfc3339 t) offset)
+      let _, (_, offset), _ = t in
+      invalid_arg
+        (Printf.sprintf "date.ml:to_t: dt='%s', offset='%i' is invalid"
+           (to_rfc3339 t) offset
+        )
 
 let to_ptime = to_ptime_t
 
@@ -89,21 +117,23 @@ let of_ptime t = Ptime.to_date_time t |> of_dt utc
 
 let of_unix_time s =
   match Ptime.of_float_s s with
-  | None -> invalid_arg (Printf.sprintf "%s: %f" __FUNCTION__ s)
-  | Some t -> of_ptime t
+  | None ->
+      invalid_arg (Printf.sprintf "%s: %f" __FUNCTION__ s)
+  | Some t ->
+      of_ptime t
 
 let to_unix_time t = to_ptime_t t |> Ptime.to_float_s
 
 let _localtime current_tz_offset t =
   let tz_offset_s = current_tz_offset |> Option.value ~default:0 in
   let localtime = t |> Ptime.to_date_time ~tz_offset_s |> of_dt Empty in
-  let (_, (_, localtime_offset), _) = localtime in
+  let _, (_, localtime_offset), _ = localtime in
   if localtime_offset <> tz_offset_s then
-    invalid_arg (
-      Printf.sprintf "date.ml:_localtime: offsets don't match. offset='%i', t='%s'"
-        tz_offset_s
-        (Ptime.to_rfc3339 t)
-    );
+    invalid_arg
+      (Printf.sprintf
+         "date.ml:_localtime: offsets don't match. offset='%i', t='%s'"
+         tz_offset_s (Ptime.to_rfc3339 t)
+      ) ;
   localtime
 
 let _localtime_string current_tz_offset t =
@@ -129,4 +159,3 @@ let to_string = to_rfc3339
 let of_float = of_unix_time
 
 let to_float = to_unix_time
-

--- a/lib/xapi-stdext-date/date.mli
+++ b/lib/xapi-stdext-date/date.mli
@@ -18,19 +18,19 @@
 (** An ISO-8601 date/time type. *)
 type iso8601
 
-(** Convert ptime to time in UTC *)
 val of_ptime : Ptime.t -> iso8601
+(** Convert ptime to time in UTC *)
 
+val to_ptime : iso8601 -> Ptime.t
 (** Convert date/time to a ptime value: the number of seconds since 00:00:00
     UTC, 1 Jan 1970. Assumes the underlying iso8601 is in UTC *)
-val to_ptime : iso8601 -> Ptime.t
 
-(** Convert calendar time [x] (as returned by e.g. Unix.time), to time in UTC. *)
 val of_unix_time : float -> iso8601
+(** Convert calendar time [x] (as returned by e.g. Unix.time), to time in UTC. *)
 
+val to_unix_time : iso8601 -> float
 (** Convert date/time to a unix timestamp: the number of seconds since 
     00:00:00 UTC, 1 Jan 1970. Assumes the underlying iso8601 is in UTC *)
-val to_unix_time : iso8601 -> float
 
 val to_rfc3339 : iso8601 -> string
 (** Convert date/time to an RFC-3339-formatted string. It also complies with
@@ -40,35 +40,36 @@ val of_iso8601 : string -> iso8601
 (** Convert ISO 8601 formatted string to a date/time value. Does not accept a
     timezone annotated datetime - i.e. string must be UTC, and end with a Z *)
 
-(** Same as [of_unix_time] *)
 val of_float : float -> iso8601
+(** Same as [of_unix_time] *)
 
-(** Same as [to_unix_time] *)
 val to_float : iso8601 -> float
+(** Same as [to_unix_time] *)
 
-(** Convert date/time to an ISO 8601 formatted string. *)
 val to_string : iso8601 -> string
+(** Convert date/time to an ISO 8601 formatted string. *)
 
+val of_string : string -> iso8601
 (** Convert ISO 8601 formatted string to a date/time value.
   * Does not accept a timezone annotated datetime - i.e. string must be UTC, and end with a Z *)
-val of_string : string -> iso8601
 
+val assert_utc : iso8601 -> unit
+  [@@deprecated
+    "assertions performed inside constructors, so this fn does nothing"]
 (** Raises an Invalid_argument exception if the given date is not a UTC date.
  *  A UTC date is an ISO 8601 strings that ends with the character 'Z'. *)
-val assert_utc : iso8601 -> unit
-[@@deprecated "assertions performed inside constructors, so this fn does nothing"]
 
+val epoch : iso8601
 (** 00:00:00 UTC, 1 Jan 1970, in UTC *)
-val epoch: iso8601
 
+val never : iso8601
 (** Same as [epoch] *)
-val never: iso8601
 
-(** Count the number of seconds passed since 00:00:00 UTC, 1 Jan 1970, in UTC *)
 val now : unit -> iso8601
+(** Count the number of seconds passed since 00:00:00 UTC, 1 Jan 1970, in UTC *)
 
-(** exposed for testing *)
 val _localtime_string : Ptime.tz_offset_s option -> Ptime.t -> string
+(** exposed for testing *)
 
 val localtime : unit -> iso8601
 
@@ -77,10 +78,10 @@ val localtime : unit -> iso8601
 (** An RFC 822 date/time type. *)
 type rfc822
 
-(** Convert calendar time [x] (as returned by e.g. Unix.time), to RFC 822. *)
 val rfc822_of_float : float -> rfc822
+(** Convert calendar time [x] (as returned by e.g. Unix.time), to RFC 822. *)
 
-(** Convert RFC 822 date/time to a formatted string. *)
 val rfc822_to_string : rfc822 -> string
+(** Convert RFC 822 date/time to a formatted string. *)
 
 val eq : iso8601 -> iso8601 -> bool

--- a/lib/xapi-stdext-date/date.mli
+++ b/lib/xapi-stdext-date/date.mli
@@ -18,11 +18,32 @@
 (** An ISO-8601 date/time type. *)
 type iso8601
 
+(** Convert ptime to time in UTC *)
+val of_ptime : Ptime.t -> iso8601
+
+(** Convert date/time to a ptime value: the number of seconds since 00:00:00
+    UTC, 1 Jan 1970. Assumes the underlying iso8601 is in UTC *)
+val to_ptime : iso8601 -> Ptime.t
+
 (** Convert calendar time [x] (as returned by e.g. Unix.time), to time in UTC. *)
+val of_unix_time : float -> iso8601
+
+(** Convert date/time to a unix timestamp: the number of seconds since 
+    00:00:00 UTC, 1 Jan 1970. Assumes the underlying iso8601 is in UTC *)
+val to_unix_time : iso8601 -> float
+
+val to_rfc3339 : iso8601 -> string
+(** Convert date/time to an RFC-3339-formatted string. It also complies with
+    the ISO 8601 format.*)
+
+val of_iso8601 : string -> iso8601
+(** Convert ISO 8601 formatted string to a date/time value. Does not accept a
+    timezone annotated datetime - i.e. string must be UTC, and end with a Z *)
+
+(** Same as [of_unix_time] *)
 val of_float : float -> iso8601
 
-(** Convert date/time to a float value: the number of seconds since 00:00:00 UTC, 1 Jan 1970.
-  * Assumes the underlying iso8601 is in UTC *)
+(** Same as [to_unix_time] *)
 val to_float : iso8601 -> float
 
 (** Convert date/time to an ISO 8601 formatted string. *)
@@ -37,8 +58,14 @@ val of_string : string -> iso8601
 val assert_utc : iso8601 -> unit
 [@@deprecated "assertions performed inside constructors, so this fn does nothing"]
 
-(** Representation of the concept "never" (actually 00:00:00 UTC, 1 Jan 1970). *)
+(** 00:00:00 UTC, 1 Jan 1970, in UTC *)
+val epoch: iso8601
+
+(** Same as [epoch] *)
 val never: iso8601
+
+(** Count the number of seconds passed since 00:00:00 UTC, 1 Jan 1970, in UTC *)
+val now : unit -> iso8601
 
 (** exposed for testing *)
 val _localtime_string : Ptime.tz_offset_s option -> Ptime.t -> string

--- a/lib/xapi-stdext-date/date.mli
+++ b/lib/xapi-stdext-date/date.mli
@@ -11,80 +11,82 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  *)
-(** Additional types and functions for dates *)
 
-(** {2 ISO 8601 Dates} *)
+(** date-time with support for keeping timezone for ISO 8601 conversion *)
+type t
 
-(** An ISO-8601 date/time type. *)
-type iso8601
-
-val of_ptime : Ptime.t -> iso8601
+val of_ptime : Ptime.t -> t
 (** Convert ptime to time in UTC *)
 
-val to_ptime : iso8601 -> Ptime.t
+val to_ptime : t -> Ptime.t
 (** Convert date/time to a ptime value: the number of seconds since 00:00:00
-    UTC, 1 Jan 1970. Assumes the underlying iso8601 is in UTC *)
+    UTC, 1 Jan 1970. Assumes the underlying {!t} is in UTC *)
 
-val of_unix_time : float -> iso8601
-(** Convert calendar time [x] (as returned by e.g. Unix.time), to time in UTC. *)
+val of_unix_time : float -> t
+(** Convert calendar time [x] (as returned by e.g. Unix.time), to time in UTC *)
 
-val to_unix_time : iso8601 -> float
+val to_unix_time : t -> float
 (** Convert date/time to a unix timestamp: the number of seconds since 
-    00:00:00 UTC, 1 Jan 1970. Assumes the underlying iso8601 is in UTC *)
+    00:00:00 UTC, 1 Jan 1970. Assumes the underlying {!t} is in UTC *)
 
-val to_rfc822 : iso8601 -> string
+val to_rfc822 : t -> string
 (** Convert date/time to email-formatted (RFC 822) string. *)
 
-val to_rfc3339 : iso8601 -> string
+val to_rfc3339 : t -> string
 (** Convert date/time to an RFC-3339-formatted string. It also complies with
-    the ISO 8601 format.*)
+    the ISO 8601 format *)
 
-val of_iso8601 : string -> iso8601
+val of_iso8601 : string -> t
 (** Convert ISO 8601 formatted string to a date/time value. Does not accept a
     timezone annotated datetime - i.e. string must be UTC, and end with a Z *)
 
-val of_float : float -> iso8601
-(** Same as [of_unix_time] *)
-
-val to_float : iso8601 -> float
-(** Same as [to_unix_time] *)
-
-val to_string : iso8601 -> string
-(** Convert date/time to an ISO 8601 formatted string. *)
-
-val of_string : string -> iso8601
-(** Convert ISO 8601 formatted string to a date/time value.
-  * Does not accept a timezone annotated datetime - i.e. string must be UTC, and end with a Z *)
-
-val assert_utc : iso8601 -> unit
-  [@@deprecated
-    "assertions performed inside constructors, so this fn does nothing"]
-(** Raises an Invalid_argument exception if the given date is not a UTC date.
- *  A UTC date is an ISO 8601 strings that ends with the character 'Z'. *)
-
-val epoch : iso8601
+val epoch : t
 (** 00:00:00 UTC, 1 Jan 1970, in UTC *)
 
-val never : iso8601
-(** Same as [epoch] *)
-
-val now : unit -> iso8601
+val now : unit -> t
 (** Count the number of seconds passed since 00:00:00 UTC, 1 Jan 1970, in UTC *)
 
 val _localtime_string : Ptime.tz_offset_s option -> Ptime.t -> string
 (** exposed for testing *)
 
-val localtime : unit -> iso8601
+val localtime : unit -> t
+(** Count the number of seconds passed since 00:00:00 UTC, 1 Jan 1970, in local
+    time *)
 
-(** {2 RFC 822 Dates} *)
+val eq : t -> t -> bool
+(** [eq a b] returns whether [a] and [b] are equal *)
 
-(** An RFC 822 date/time type. *)
-type rfc822
+(** Deprecated bindings, these will be removed in a future release: *)
 
-val rfc822_of_float : float -> rfc822
-(** Convert calendar time [x] (as returned by e.g. Unix.time), to RFC 822. *)
+val rfc822_to_string : t -> string
+(** Same as {!to_rfc822} *)
 
-val rfc822_to_string : rfc822 -> string
-(** Convert RFC 822 date/time to a formatted string. *)
+val rfc822_of_float : float -> t
+(** Same as {!of_unix_time} *)
 
-val eq : iso8601 -> iso8601 -> bool
+val of_float : float -> t
+(** Same as {!of_unix_time} *)
+
+val to_float : t -> float
+(** Same as {!to_unix_time} *)
+
+val to_string : t -> string
+(** Same as {!to_rfc3339} *)
+
+val of_string : string -> t
+(** Same as {!of_iso8601} *)
+
+val never : t
+(** Same as {!epoch} *)
+
+val assert_utc : t -> unit
+  [@@deprecated
+    "assertions performed inside constructors, so this fn does nothing"]
+(** Raises an Invalid_argument exception if the given date is not a UTC date.
+    A UTC date is an ISO 8601 strings that ends with the character 'Z' *)
+
+(** Deprecated alias for {!t} *)
+type iso8601 = t
+
+(** Deprecated alias for {!t} *)
+type rfc822 = t

--- a/lib/xapi-stdext-date/date.mli
+++ b/lib/xapi-stdext-date/date.mli
@@ -32,6 +32,9 @@ val to_unix_time : iso8601 -> float
 (** Convert date/time to a unix timestamp: the number of seconds since 
     00:00:00 UTC, 1 Jan 1970. Assumes the underlying iso8601 is in UTC *)
 
+val to_rfc822 : iso8601 -> string
+(** Convert date/time to email-formatted (RFC 822) string. *)
+
 val to_rfc3339 : iso8601 -> string
 (** Convert date/time to an RFC-3339-formatted string. It also complies with
     the ISO 8601 format.*)

--- a/lib/xapi-stdext-date/test.ml
+++ b/lib/xapi-stdext-date/test.ml
@@ -12,7 +12,7 @@ let dash_time_str = "2020-04-07T08:28:32Z"
 
 let no_dash_utc_time_str = "20200407T08:28:32Z"
 
-let iso8601_tests =
+let tests =
   let test_of_unix_time_invertible () =
     let non_int_time = 1586245987.70200706 in
     let time = non_int_time |> Float.floor in
@@ -24,32 +24,35 @@ let iso8601_tests =
   in
   let test_only_utc () =
     let utc = "2020-12-20T18:10:19Z" in
-    let _ = of_string utc in
+    let _ = of_iso8601 utc in
     (* UTC is valid *)
     let non_utc = "2020-12-20T18:10:19+02:00" in
-    let exn = Invalid_argument "date.ml:of_string: 2020-12-20T18:10:19+02:00" in
+    let exn =
+      Invalid_argument
+        "Xapi_stdext_date__Date.of_iso8601: 2020-12-20T18:10:19+02:00"
+    in
     Alcotest.check_raises "only UTC is accepted" exn (fun () ->
-        of_string non_utc |> ignore
+        of_iso8601 non_utc |> ignore
     )
   in
   let test_ca333908 () =
     check_float "dash time and no dash time represent the same unix timestamp"
-      (dash_time_str |> of_string |> to_unix_time)
-      (no_dash_utc_time_str |> of_string |> to_unix_time)
+      (dash_time_str |> of_iso8601 |> to_unix_time)
+      (no_dash_utc_time_str |> of_iso8601 |> to_unix_time)
   in
-  let test_of_string_invertible_when_no_dashes () =
-    check_string "to_string inverts of_string" no_dash_utc_time_str
-      (no_dash_utc_time_str |> of_string |> to_string) ;
-    check_true "of_string inverts to_string"
+  let test_of_iso8601_invertible_when_no_dashes () =
+    check_string "to_rfc3339 inverts of_iso8601" no_dash_utc_time_str
+      (no_dash_utc_time_str |> of_iso8601 |> to_rfc3339) ;
+    check_true "of_iso8601 inverts to_rfc3339"
       (eq
-         (no_dash_utc_time_str |> of_string)
-         (no_dash_utc_time_str |> of_string |> to_string |> of_string)
+         (no_dash_utc_time_str |> of_iso8601)
+         (no_dash_utc_time_str |> of_iso8601 |> to_rfc3339 |> of_iso8601)
       )
   in
   (* CA-338243 - breaking backwards compatibility will break XC and XRT *)
-  let test_to_string_backwards_compatibility () =
-    check_string "to_string is backwards compatible" no_dash_utc_time_str
-      (dash_time_str |> of_string |> to_string)
+  let test_to_rfc3339_backwards_compatibility () =
+    check_string "to_rfc3339 is backwards compatible" no_dash_utc_time_str
+      (dash_time_str |> of_iso8601 |> to_rfc3339)
   in
   let test_localtime_string () =
     let[@warning "-8"] (Ok (t, _, _)) =
@@ -72,7 +75,7 @@ let iso8601_tests =
   (* sanity check (on top of test_localtime_string) that localtime produces valid looking output *)
   let test_ca342171 () =
     (* no exception is thrown + backward compatible formatting *)
-    let localtime_string = localtime () |> to_string in
+    let localtime_string = localtime () |> to_rfc3339 in
     Alcotest.(check int)
       "localtime string has correct number of chars"
       (String.length localtime_string)
@@ -85,49 +88,48 @@ let iso8601_tests =
     let missing_tz_no_dash = "20201210T17:19:20" in
     let missing_tz_dash = "2020-12-10T17:19:20" in
     check_string "can process missing tz no dash" missing_tz_no_dash
-      (missing_tz_no_dash |> of_string |> to_string) ;
+      (missing_tz_no_dash |> of_iso8601 |> to_rfc3339) ;
     check_string "can process missing tz with dashes, but return without dashes"
       missing_tz_no_dash
-      (missing_tz_dash |> of_string |> to_string) ;
+      (missing_tz_dash |> of_iso8601 |> to_rfc3339) ;
     check_float "to_unix_time assumes UTC" 1607620760.
-      (missing_tz_no_dash |> of_string |> to_unix_time) ;
+      (missing_tz_no_dash |> of_iso8601 |> to_unix_time) ;
     let localtime' = localtime () in
-    check_string "to_string inverts of_string for localtime"
-      (localtime' |> to_string)
-      (localtime' |> to_string |> of_string |> to_string)
+    check_string "to_rfc3339 inverts of_iso8601 for localtime"
+      (localtime' |> to_rfc3339)
+      (localtime' |> to_rfc3339 |> of_iso8601 |> to_rfc3339)
+  in
+  let test_email_date (unix_timestamp, expected) =
+    let formatted = of_unix_time unix_timestamp |> to_rfc822 in
+    check_string "String is properly RFC-822-formatted" expected formatted
+  in
+  let test_email_dates () =
+    let dates =
+      [
+        (-1221847200., "Tue, 14 Apr 1931 06:00:00 GMT")
+      ; (0., "Thu, 1 Jan 1970 00:00:00 GMT")
+      ; (626637180., "Thu, 9 Nov 1989 17:53:00 GMT")
+      ; (2889734400., "Thu, 28 Jul 2061 00:00:00 GMT")
+      ]
+    in
+    List.iter test_email_date dates
   in
   [
     ("test_of_unix_time_invertible", `Quick, test_of_unix_time_invertible)
   ; ("test_only_utc", `Quick, test_only_utc)
   ; ("test_ca333908", `Quick, test_ca333908)
-  ; ( "test_of_string_invertible_when_no_dashes"
+  ; ( "test_of_iso8601_invertible_when_no_dashes"
     , `Quick
-    , test_of_string_invertible_when_no_dashes
+    , test_of_iso8601_invertible_when_no_dashes
     )
-  ; ( "test_to_string_backwards_compatibility"
+  ; ( "test_to_rfc3339_backwards_compatibility"
     , `Quick
-    , test_to_string_backwards_compatibility
+    , test_to_rfc3339_backwards_compatibility
     )
   ; ("test_localtime_string", `Quick, test_localtime_string)
   ; ("test_ca342171", `Quick, test_ca342171)
   ; ("test_xsi894", `Quick, test_xsi894)
+  ; ("RFC 822 formatting", `Quick, test_email_dates)
   ]
 
-let rfc822_tests =
-  let dates =
-    [
-      (-1221847200., "Tue, 14 Apr 1931 06:00:00 GMT")
-    ; (0., "Thu, 1 Jan 1970 00:00:00 GMT")
-    ; (626637180., "Thu, 9 Nov 1989 17:53:00 GMT")
-    ; (2889734400., "Thu, 28 Jul 2061 00:00:00 GMT")
-    ]
-  in
-  let test_email_date (unix_timestamp, expected) =
-    let formatted = rfc822_of_float unix_timestamp |> rfc822_to_string in
-    check_string "String is properly RFC-822-formatted" expected formatted
-  in
-  let test_email_dates () = List.iter test_email_date dates in
-  [("RFC 822 formatting", `Quick, test_email_dates)]
-
-let () =
-  Alcotest.run "Date" [("ISO 8601", iso8601_tests); ("RFC 822", rfc822_tests)]
+let () = Alcotest.run "Date" [("Conversions", tests)]

--- a/lib/xapi-stdext-date/test.ml
+++ b/lib/xapi-stdext-date/test.ml
@@ -8,11 +8,11 @@ let dash_time_str = "2020-04-07T08:28:32Z"
 let no_dash_utc_time_str = "20200407T08:28:32Z"
 
 let iso8601_tests =
-  let test_of_float_invertible () =
+  let test_of_unix_time_invertible () =
     let non_int_time = 1586245987.70200706 in
     let time = non_int_time |> Float.floor in
-    check_float "to_float inverts of_float" time (time |> of_float |> to_float);
-    check_true "of_float inverts to_float" @@ eq (time |> of_float) (time |> of_float |> to_float |> of_float);
+    check_float "to_unix_time inverts of_unix_time" time (time |> of_unix_time |> to_unix_time);
+    check_true "of_unix_time inverts to_unix_time" @@ eq (time |> of_unix_time) (time |> of_unix_time |> to_unix_time |> of_unix_time);
   in
 
   let test_only_utc () =
@@ -24,9 +24,9 @@ let iso8601_tests =
   in
 
   let test_ca333908 () =
-    check_float "dash time and no dash time have same float repr"
-                (dash_time_str |> of_string |> to_float)
-                (no_dash_utc_time_str |> of_string |> to_float)
+    check_float "dash time and no dash time represent the same unix timestamp"
+                (dash_time_str |> of_string |> to_unix_time)
+                (no_dash_utc_time_str |> of_string |> to_unix_time)
   in
 
   let test_of_string_invertible_when_no_dashes () =
@@ -68,13 +68,13 @@ let iso8601_tests =
     check_string "can process missing tz no dash" missing_tz_no_dash (missing_tz_no_dash |> of_string |> to_string) ;
     check_string "can process missing tz with dashes, but return without dashes" missing_tz_no_dash (missing_tz_dash |> of_string |> to_string) ;
 
-    check_float "to_float assumes UTC" 1607620760. (missing_tz_no_dash |> of_string |> to_float) ;
+    check_float "to_unix_time assumes UTC" 1607620760. (missing_tz_no_dash |> of_string |> to_unix_time) ;
 
     let localtime' = localtime () in
     check_string "to_string inverts of_string for localtime" (localtime' |> to_string) (localtime' |> to_string |> of_string |> to_string) ;
   in
 
-  [ "test_of_float_invertible", `Quick, test_of_float_invertible
+  [ "test_of_unix_time_invertible", `Quick, test_of_unix_time_invertible
   ; "test_only_utc", `Quick, test_only_utc
   ; "test_ca333908", `Quick, test_ca333908
   ; "test_of_string_invertible_when_no_dashes", `Quick, test_of_string_invertible_when_no_dashes

--- a/lib/xapi-stdext-date/test.ml
+++ b/lib/xapi-stdext-date/test.ml
@@ -1,45 +1,56 @@
 open Xapi_stdext_date.Date
 
-let check_float = Alcotest.(check @@ float 1e-2 )
+let check_float = Alcotest.(check @@ float 1e-2)
+
 let check_float_neq = Alcotest.(check @@ neg @@ float 1e-2)
+
 let check_string = Alcotest.(check string)
+
 let check_true str = Alcotest.(check bool) str true
+
 let dash_time_str = "2020-04-07T08:28:32Z"
+
 let no_dash_utc_time_str = "20200407T08:28:32Z"
 
 let iso8601_tests =
   let test_of_unix_time_invertible () =
     let non_int_time = 1586245987.70200706 in
     let time = non_int_time |> Float.floor in
-    check_float "to_unix_time inverts of_unix_time" time (time |> of_unix_time |> to_unix_time);
-    check_true "of_unix_time inverts to_unix_time" @@ eq (time |> of_unix_time) (time |> of_unix_time |> to_unix_time |> of_unix_time);
+    check_float "to_unix_time inverts of_unix_time" time
+      (time |> of_unix_time |> to_unix_time) ;
+    check_true "of_unix_time inverts to_unix_time"
+    @@ eq (time |> of_unix_time)
+         (time |> of_unix_time |> to_unix_time |> of_unix_time)
   in
-
   let test_only_utc () =
     let utc = "2020-12-20T18:10:19Z" in
-    let _ = of_string utc in (* UTC is valid *)
+    let _ = of_string utc in
+    (* UTC is valid *)
     let non_utc = "2020-12-20T18:10:19+02:00" in
     let exn = Invalid_argument "date.ml:of_string: 2020-12-20T18:10:19+02:00" in
-    Alcotest.check_raises "only UTC is accepted" exn (fun () ->  of_string non_utc |> ignore)
+    Alcotest.check_raises "only UTC is accepted" exn (fun () ->
+        of_string non_utc |> ignore
+    )
   in
-
   let test_ca333908 () =
     check_float "dash time and no dash time represent the same unix timestamp"
-                (dash_time_str |> of_string |> to_unix_time)
-                (no_dash_utc_time_str |> of_string |> to_unix_time)
+      (dash_time_str |> of_string |> to_unix_time)
+      (no_dash_utc_time_str |> of_string |> to_unix_time)
   in
-
   let test_of_string_invertible_when_no_dashes () =
-    check_string "to_string inverts of_string" no_dash_utc_time_str (no_dash_utc_time_str |> of_string |> to_string);
-    check_true "of_string inverts to_string" (eq (no_dash_utc_time_str |> of_string) (no_dash_utc_time_str |> of_string |> to_string |> of_string));
+    check_string "to_string inverts of_string" no_dash_utc_time_str
+      (no_dash_utc_time_str |> of_string |> to_string) ;
+    check_true "of_string inverts to_string"
+      (eq
+         (no_dash_utc_time_str |> of_string)
+         (no_dash_utc_time_str |> of_string |> to_string |> of_string)
+      )
   in
-
   (* CA-338243 - breaking backwards compatibility will break XC and XRT *)
   let test_to_string_backwards_compatibility () =
     check_string "to_string is backwards compatible" no_dash_utc_time_str
       (dash_time_str |> of_string |> to_string)
   in
-
   let test_localtime_string () =
     let[@warning "-8"] (Ok (t, _, _)) =
       Ptime.of_rfc3339 "2020-04-07T09:01:28Z"
@@ -47,41 +58,59 @@ let iso8601_tests =
     let minus_2_hrs = -7200 in
     let plus_3_hrs = 10800 in
     let zero_hrs = 0 in
-    check_string "can subtract 2 hours" (_localtime_string (Some minus_2_hrs) t) "20200407T07:01:28";
-    check_string "can add 3 hours" (_localtime_string (Some plus_3_hrs) t) "20200407T12:01:28";
-    check_string "can add None" (_localtime_string None t) "20200407T09:01:28";
-    check_string "can add zero" (_localtime_string (Some zero_hrs) t) "20200407T09:01:28"
+    check_string "can subtract 2 hours"
+      (_localtime_string (Some minus_2_hrs) t)
+      "20200407T07:01:28" ;
+    check_string "can add 3 hours"
+      (_localtime_string (Some plus_3_hrs) t)
+      "20200407T12:01:28" ;
+    check_string "can add None" (_localtime_string None t) "20200407T09:01:28" ;
+    check_string "can add zero"
+      (_localtime_string (Some zero_hrs) t)
+      "20200407T09:01:28"
   in
-
   (* sanity check (on top of test_localtime_string) that localtime produces valid looking output *)
   let test_ca342171 () =
     (* no exception is thrown + backward compatible formatting *)
     let localtime_string = localtime () |> to_string in
-    Alcotest.(check int) "localtime string has correct number of chars"
-      (String.length localtime_string) (String.length no_dash_utc_time_str - 1);
-    Alcotest.(check bool) "localtime string does not contain a Z" false (String.contains localtime_string 'Z')
+    Alcotest.(check int)
+      "localtime string has correct number of chars"
+      (String.length localtime_string)
+      (String.length no_dash_utc_time_str - 1) ;
+    Alcotest.(check bool)
+      "localtime string does not contain a Z" false
+      (String.contains localtime_string 'Z')
   in
-
   let test_xsi894 () =
     let missing_tz_no_dash = "20201210T17:19:20" in
     let missing_tz_dash = "2020-12-10T17:19:20" in
-    check_string "can process missing tz no dash" missing_tz_no_dash (missing_tz_no_dash |> of_string |> to_string) ;
-    check_string "can process missing tz with dashes, but return without dashes" missing_tz_no_dash (missing_tz_dash |> of_string |> to_string) ;
-
-    check_float "to_unix_time assumes UTC" 1607620760. (missing_tz_no_dash |> of_string |> to_unix_time) ;
-
+    check_string "can process missing tz no dash" missing_tz_no_dash
+      (missing_tz_no_dash |> of_string |> to_string) ;
+    check_string "can process missing tz with dashes, but return without dashes"
+      missing_tz_no_dash
+      (missing_tz_dash |> of_string |> to_string) ;
+    check_float "to_unix_time assumes UTC" 1607620760.
+      (missing_tz_no_dash |> of_string |> to_unix_time) ;
     let localtime' = localtime () in
-    check_string "to_string inverts of_string for localtime" (localtime' |> to_string) (localtime' |> to_string |> of_string |> to_string) ;
+    check_string "to_string inverts of_string for localtime"
+      (localtime' |> to_string)
+      (localtime' |> to_string |> of_string |> to_string)
   in
-
-  [ "test_of_unix_time_invertible", `Quick, test_of_unix_time_invertible
-  ; "test_only_utc", `Quick, test_only_utc
-  ; "test_ca333908", `Quick, test_ca333908
-  ; "test_of_string_invertible_when_no_dashes", `Quick, test_of_string_invertible_when_no_dashes
-  ; "test_to_string_backwards_compatibility", `Quick, test_to_string_backwards_compatibility
-  ; "test_localtime_string", `Quick, test_localtime_string
-  ; "test_ca342171", `Quick, test_ca342171
-  ; "test_xsi894", `Quick, test_xsi894
+  [
+    ("test_of_unix_time_invertible", `Quick, test_of_unix_time_invertible)
+  ; ("test_only_utc", `Quick, test_only_utc)
+  ; ("test_ca333908", `Quick, test_ca333908)
+  ; ( "test_of_string_invertible_when_no_dashes"
+    , `Quick
+    , test_of_string_invertible_when_no_dashes
+    )
+  ; ( "test_to_string_backwards_compatibility"
+    , `Quick
+    , test_to_string_backwards_compatibility
+    )
+  ; ("test_localtime_string", `Quick, test_localtime_string)
+  ; ("test_ca342171", `Quick, test_ca342171)
+  ; ("test_xsi894", `Quick, test_xsi894)
   ]
 
-let () = Alcotest.run "Date" [ "ISO 8601", iso8601_tests ]
+let () = Alcotest.run "Date" [("ISO 8601", iso8601_tests)]

--- a/lib/xapi-stdext-date/test.ml
+++ b/lib/xapi-stdext-date/test.ml
@@ -113,4 +113,21 @@ let iso8601_tests =
   ; ("test_xsi894", `Quick, test_xsi894)
   ]
 
-let () = Alcotest.run "Date" [("ISO 8601", iso8601_tests)]
+let rfc822_tests =
+  let dates =
+    [
+      (-1221847200., "Tue, 14 Apr 1931 06:00:00 GMT")
+    ; (0., "Thu, 1 Jan 1970 00:00:00 GMT")
+    ; (626637180., "Thu, 9 Nov 1989 17:53:00 GMT")
+    ; (2889734400., "Thu, 28 Jul 2061 00:00:00 GMT")
+    ]
+  in
+  let test_email_date (unix_timestamp, expected) =
+    let formatted = rfc822_of_float unix_timestamp |> rfc822_to_string in
+    check_string "String is properly RFC-822-formatted" expected formatted
+  in
+  let test_email_dates () = List.iter test_email_date dates in
+  [("RFC 822 formatting", `Quick, test_email_dates)]
+
+let () =
+  Alcotest.run "Date" [("ISO 8601", iso8601_tests); ("RFC 822", rfc822_tests)]


### PR DESCRIPTION
Currently the only way to create dates is from floats, since this is quite non-descript semantically, add a new name for these conversion functions, stating that they are meant to be unix timestamps, and allow conversions to and from ptime, which is now the main actual type that implements dates.

There's a new helper function to get the current time in date form as well.

The origin of unix time has been renamed to `epoch`from `never`: having never being equal to is not quite accurate even if in reality the value should be very rare.

In the future the functions with `float` in the name and `never` will be deprecated. not forcing it here allows to have a non-breaking transition path