### PR TITLE
date, pervasive, std: remove deprecated code

### DIFF
--- a/lib/xapi-stdext-date/date.ml
+++ b/lib/xapi-stdext-date/date.ml
@@ -149,8 +149,6 @@ let epoch = of_ptime Ptime.epoch
 
 let eq x y = x = y
 
-let assert_utc _ = ()
-
 let never = epoch
 
 let of_string = of_iso8601

--- a/lib/xapi-stdext-date/date.ml
+++ b/lib/xapi-stdext-date/date.ml
@@ -147,7 +147,28 @@ let now () = of_ptime (Ptime_clock.now ())
 
 let epoch = of_ptime Ptime.epoch
 
-let eq x y = x = y
+let is_earlier ~than t = Ptime.is_earlier ~than:(to_ptime than) (to_ptime t)
+
+let is_later ~than t = Ptime.is_later ~than:(to_ptime than) (to_ptime t)
+
+let diff a b = Ptime.diff (to_ptime a) (to_ptime b)
+
+let compare_print_tz a b =
+  match (a, b) with
+  | Empty, Empty ->
+      0
+  | TZ a_s, TZ b_s ->
+      String.compare a_s b_s
+  | Empty, TZ _ ->
+      -1
+  | TZ _, Empty ->
+      1
+
+let compare ((_, _, a_z) as a) ((_, _, b_z) as b) =
+  let ( <?> ) a b = if a = 0 then b else a in
+  Ptime.compare (to_ptime a) (to_ptime b) <?> compare_print_tz a_z b_z
+
+let eq x y = compare x y = 0
 
 let never = epoch
 

--- a/lib/xapi-stdext-date/date.mli
+++ b/lib/xapi-stdext-date/date.mli
@@ -15,6 +15,8 @@
 (** date-time with support for keeping timezone for ISO 8601 conversion *)
 type t
 
+(** Conversions *)
+
 val of_ptime : Ptime.t -> t
 (** Convert ptime to time in UTC *)
 
@@ -26,7 +28,7 @@ val of_unix_time : float -> t
 (** Convert calendar time [x] (as returned by e.g. Unix.time), to time in UTC *)
 
 val to_unix_time : t -> float
-(** Convert date/time to a unix timestamp: the number of seconds since 
+(** Convert date/time to a unix timestamp: the number of seconds since
     00:00:00 UTC, 1 Jan 1970. Assumes the underlying {!t} is in UTC *)
 
 val to_rfc822 : t -> string
@@ -53,8 +55,25 @@ val localtime : unit -> t
 (** Count the number of seconds passed since 00:00:00 UTC, 1 Jan 1970, in local
     time *)
 
+(** Comparisons *)
+
 val eq : t -> t -> bool
 (** [eq a b] returns whether [a] and [b] are equal *)
+
+val compare : t -> t -> int
+(** [compare a b] returns -1 if [a] is earlier than [b], 1 if [a] is later than
+    [b] or the ordering of the timezone printer *)
+
+val is_earlier : than:t -> t -> bool
+(** [is_earlier ~than a] returns whether the timestamp [a] happens before
+    [than] *)
+
+val is_later : than:t -> t -> bool
+(** [is_later ~than a] returns whether the timestamp [a] happens after [than]
+    *)
+
+val diff : t -> t -> Ptime.Span.t
+(** [diff a b] returns the span of time corresponding to [a - b] *)
 
 (** Deprecated bindings, these will be removed in a future release: *)
 

--- a/lib/xapi-stdext-date/date.mli
+++ b/lib/xapi-stdext-date/date.mli
@@ -79,14 +79,8 @@ val of_string : string -> t
 val never : t
 (** Same as {!epoch} *)
 
-val assert_utc : t -> unit
-  [@@deprecated
-    "assertions performed inside constructors, so this fn does nothing"]
-(** Raises an Invalid_argument exception if the given date is not a UTC date.
-    A UTC date is an ISO 8601 strings that ends with the character 'Z' *)
-
-(** Deprecated alias for {!t} *)
 type iso8601 = t
-
 (** Deprecated alias for {!t} *)
+
 type rfc822 = t
+(** Deprecated alias for {!t} *)

--- a/lib/xapi-stdext-pervasives/pervasiveext.ml
+++ b/lib/xapi-stdext-pervasives/pervasiveext.ml
@@ -39,19 +39,9 @@ let finally fct clean_f =
   in
   clean_f () ; result
 
-let maybe_with_default d f v = Option.fold ~none:d ~some:f v
-
-let may f v = Option.map f v
-
-let default d v = Option.value ~default:d v
-
-let maybe f v = Option.iter f v
 
 (** execute fct ignoring exceptions *)
 let ignore_exn fct = try fct () with _ -> ()
-
-(** if not bool ignore exceptions raised by fct () *)
-let reraise_if bool fct = if bool then fct () else ignore_exn fct
 
 (* non polymorphic ignore function *)
 let ignore_int v =
@@ -77,10 +67,3 @@ let ignore_float v =
 let ignore_bool v =
   let (_ : bool) = v in
   ()
-
-(* To avoid some parens: *)
-(* composition of functions: *)
-let ( ++ ) f g x = f (g x)
-
-(* and application *)
-let ( $ ) f a = f a

--- a/lib/xapi-stdext-pervasives/pervasiveext.mli
+++ b/lib/xapi-stdext-pervasives/pervasiveext.mli
@@ -16,27 +16,6 @@ val finally : (unit -> 'a) -> (unit -> unit) -> 'a
 (** [finally f g] returns [f ()] guaranteeing to run clean-up actions
     [g ()] even if [f ()] throws an exception. *)
 
-val maybe_with_default : 'b -> ('a -> 'b) -> 'a option -> 'b
-  [@@ocaml.deprecated "Replace with Option.fold"]
-(** [maybe_with_default d f v] is Some [f c] if [v] is [Some c] and [d]
-    otherwise. *)
-
-val may : ('a -> 'b) -> 'a option -> 'b option
-  [@@ocaml.deprecated "Replace with Option.map"]
-(** [may f v] is Some [f c] if [v] is [Some c] and None otherwise. *)
-
-val default : 'a -> 'a option -> 'a
-  [@@ocaml.deprecated "Replace with Option.value"]
-(** [default d v] is [c] if [o] is [Some c] and d otherwise. *)
-
-val maybe : ('a -> unit) -> 'a option -> unit
-  [@@ocaml.deprecated "Replace with Option.iter"]
-(** [maybe f v] is [f c] if [v] is [Some c] and [()] otherwise. *)
-
-val reraise_if : bool -> (unit -> unit) -> unit
-  [@@ocaml.deprecated "Use ignore_exn instead"]
-(** [reraise_if bool fct] runs [fct ()]. If [not bool] ignores raised exceptions *)
-
 val ignore_exn : (unit -> unit) -> unit
 
 val ignore_int : int -> unit
@@ -50,8 +29,3 @@ val ignore_string : string -> unit
 val ignore_float : float -> unit
 
 val ignore_bool : bool -> unit
-
-val ( ++ ) : ('b -> 'c) -> ('a -> 'b) -> 'a -> 'c
-  [@@ocaml.deprecated "Not a standard idiom. Define it locally if needed."]
-val ( $ ) : ('a -> 'b) -> 'a -> 'b
-  [@@ocaml.deprecated "Not right-associative. Replace with @@"]

--- a/lib/xapi-stdext-std/listext.ml
+++ b/lib/xapi-stdext-std/listext.ml
@@ -115,13 +115,6 @@ module List = struct
     | _ ->
         invalid_arg "remove"
 
-  let extract i l =
-    match rev_chop i l with
-    | rfr, h :: t ->
-        (h, rev_append rfr t)
-    | _ ->
-        invalid_arg "extract"
-
   let insert i e l =
     match rev_chop i l with rfr, ba -> rev_append rfr (e :: ba)
 
@@ -157,58 +150,6 @@ module List = struct
           aux (e :: h :: accu) e t
     in
     aux [] e l
-
-  let randomize l =
-    let extract_rand l = extract (Random.int (length l)) l in
-    let rec aux accu = function
-      | [] ->
-          accu
-      | l ->
-          (fun (h, t) -> aux (h :: accu) t) (extract_rand l)
-    in
-    aux [] l
-
-  let rec distribute e = function
-    | h :: t as l ->
-        (e :: l) :: map (fun x -> h :: x) (distribute e t)
-    | [] ->
-        [[e]]
-
-  let rec permute = function
-    | e :: rest ->
-        flatten (map (distribute e) (permute rest))
-    | [] ->
-        [[]]
-
-  let rec aux_rle_eq eq l2 x n = function
-    | [] ->
-        rev ((x, n) :: l2)
-    | h :: t when eq x h ->
-        aux_rle_eq eq l2 x (n + 1) t
-    | h :: t ->
-        aux_rle_eq eq ((x, n) :: l2) h 1 t
-
-  let rle_eq eq l = match l with [] -> [] | h :: t -> aux_rle_eq eq [] h 1 t
-
-  let rle l = rle_eq ( = ) l
-
-  let unrle l =
-    let rec aux2 accu i c =
-      match i with
-      | 0 ->
-          accu
-      | i when i > 0 ->
-          aux2 (c :: accu) (i - 1) c
-      | _ ->
-          invalid_arg "unrle"
-    in
-    let rec aux accu = function
-      | [] ->
-          rev accu
-      | (i, c) :: t ->
-          aux (aux2 accu i c) t
-    in
-    aux [] l
 
   let inner fold_left2 base f l1 l2 g =
     fold_left2 (fun accu e1 e2 -> g accu (f e1 e2)) base l1 l2

--- a/lib/xapi-stdext-std/listext.mli
+++ b/lib/xapi-stdext-std/listext.mli
@@ -120,20 +120,6 @@ module List : sig
   (** {1 Run-length encoded lists}
       There are no known users of these functions. *)
 
-  val rle : 'a list -> ('a * int) list
-    [@@deprecated
-      "No known users, consider creating a proper datatype, this kind of list \
-       might be confused with association lists"]
-  (** Run-length encodes the given list using polimorphic equality *)
-
-  val unrle : (int * 'a) list -> 'a list
-    [@@deprecated "No known users"]
-  (** Decode a run-length encoded list. *)
-
-  val rle_eq : ('a -> 'a -> bool) -> 'a list -> ('a * int) list
-    [@@deprecated "No known users"]
-  (** [rle_eq eq l] run-length encodes [l] using [eq] *)
-
   (** {1 Generative functions}
       These are usually useful for coding challenges like Advent of Code.*)
 
@@ -147,16 +133,6 @@ module List : sig
 
   val between_tr : 'a -> 'a list -> 'a list
   (** Tail-recursive {!between}. *)
-
-  val randomize : 'a list -> 'a list [@@deprecated "Not used"]
-  (** Generate a random permutation of the given list. *)
-
-  val distribute : 'a -> 'a list -> 'a list list [@@deprecated "Not used"]
-  (** Distribute the given element over the given list, returning a list of
-      lists with the new element in each position. *)
-
-  val permute : 'a list -> 'a list list [@@deprecated "Not used"]
-  (** Generate all permutations of the given list. *)
 
   val inner :
        (('a -> 'b -> 'c -> 'd) -> 'e -> 'f -> 'g -> 'h)


### PR DESCRIPTION
Since we're running make check in xapi, these are safe to remove.

On top of that I've added some comparison methods to date so users of the library don't have to do conversions before comparisons when updating functions marked as deprecated.