### PR TITLE
Optimize XML_UTF8.is_valid: avoid allocating an int32 for each unicode codepoint

### DIFF
--- a/lib/xapi-stdext-encodings/encodings.ml
+++ b/lib/xapi-stdext-encodings/encodings.ml
@@ -88,10 +88,6 @@ end
 
 (* ==== Character Codecs ==== *)
 
-module type CHARACTER_DECODER = sig
-  val decode_character : string -> int -> uchar * int
-end
-
 module UTF8_CODEC (UCS_validator : UCS_VALIDATOR) = struct
   (* === Decoding === *)
 
@@ -144,13 +140,14 @@ end
 
 exception Validation_error of int * exn
 
-module String_validator (Decoder : CHARACTER_DECODER) : STRING_VALIDATOR = struct
+module String_validator (Validator : UCS_VALIDATOR) : STRING_VALIDATOR = struct
+  include UTF8_CODEC(Validator)
 
   let validate string =
     let index = ref 0 and length = String.length string in
     begin try
         while !index < length do
-          let _, width = Decoder.decode_character string !index in
+          let _, width = decode_character string !index in
           index := !index + width
         done;
       with
@@ -167,5 +164,5 @@ module String_validator (Decoder : CHARACTER_DECODER) : STRING_VALIDATOR = struc
 
 end
 
-module UTF8     = String_validator (    UTF8_codec)
-module UTF8_XML = String_validator (XML_UTF8_codec)
+module UTF8     = String_validator (UTF8_UCS_validator)
+module UTF8_XML = String_validator (XML_UTF8_UCS_validator)

--- a/lib/xapi-stdext-encodings/encodings.mli
+++ b/lib/xapi-stdext-encodings/encodings.mli
@@ -25,13 +25,12 @@ exception UTF8_continuation_byte_invalid
 exception UTF8_encoding_not_canonical
 exception String_incomplete
 
-type uchar = int
 
 (** {2 UCS Validators} *)
 
 (** Validates UCS character values. *)
 module type UCS_VALIDATOR = sig
-  val validate : uchar -> unit
+  val validate : Uchar.t -> unit
 end
 
 (** Accepts all values within the UCS character value range except
@@ -42,7 +41,7 @@ module XML : sig
   (** Returns true if and only if the given value corresponds to
       	 *  a forbidden control character as defined in section 2.2 of
       	 *  the XML specification, version 1.0. *)
-  val is_forbidden_control_character : uchar -> bool
+  val is_forbidden_control_character : Uchar.t -> bool
 end
 
 (** {2 String Validators} *)

--- a/lib/xapi-stdext-encodings/encodings.mli
+++ b/lib/xapi-stdext-encodings/encodings.mli
@@ -34,42 +34,9 @@ module type UCS_VALIDATOR = sig
   val validate : uchar -> unit
 end
 
-(** Accepts all values within the UCS character value range
- *  except those which are invalid for all UTF-8 documents. *)
-module UTF8_UCS_validator : UCS_VALIDATOR
-
 (** Accepts all values within the UCS character value range except
  *  those which are invalid for all UTF-8-encoded XML documents. *)
 module XML_UTF8_UCS_validator : UCS_VALIDATOR
-
-module UCS : sig
-  val min_value : uchar
-  val max_value : uchar
-
-  (** Returns true if and only if the given value corresponds to a UCS
-      	 *  non-character. Such non-characters are forbidden for use in open
-      	 *  interchange of Unicode text data, and include the following:
-      	 *    1. values from 0xFDD0 to 0xFDEF; and
-      	 *    2. values 0xnFFFE and 0xnFFFF, where (0x0 <= n <= 0x10).
-      	 *  See the Unicode 5.0 Standard, section 16.7 for further details. *)
-  val is_non_character : uchar -> bool
-
-  (** Returns true if and only if the given value lies outside the
-      	 *  entire UCS range. *)
-  val is_out_of_range : uchar -> bool
-
-  (** Returns true if and only if the given value corresponds to a UCS
-      	 *  surrogate code point, only for use in UTF-16 encoded strings.
-      	 *  See the Unicode 5.0 Standard, section 16.6 for further details. *)
-  val is_surrogate : uchar -> bool
-end
-
-val (+++) : uchar -> uchar -> uchar
-val (---) : uchar -> uchar -> uchar
-val (&&&) : uchar -> uchar -> uchar
-val (|||) : uchar -> uchar -> uchar
-val (<<<) : uchar -> int -> uchar
-val (>>>) : uchar -> int -> uchar
 
 module XML : sig
   (** Returns true if and only if the given value corresponds to
@@ -79,14 +46,6 @@ module XML : sig
 end
 
 (** {2 Character Codecs} *)
-
-module type CHARACTER_ENCODER = sig
-
-  (** Encodes a single character value, returning a string containing
-      	 *  the character. Raises an error if the character value is invalid. *)
-  val encode_character : uchar -> string
-
-end
 
 module type CHARACTER_DECODER = sig
   (** Decodes a single character embedded within a string. Given a string
@@ -98,68 +57,8 @@ module type CHARACTER_DECODER = sig
 end
 
 module UTF8_CODEC (UCS_validator : UCS_VALIDATOR) : sig
-  (** Given a valid UCS value, returns the canonical
-      	 *  number of bytes required to encode the value. *)
-  val width_required_for_ucs_value : uchar -> int
-
-  (** {3 Decoding} *)
-
-  (** Decodes a header byte, returning a tuple (v, w) where:
-      	 *  v = the (partial) value contained within the byte; and
-      	 *  w = the total width of the encoded character, in bytes. *)
-  val decode_header_byte : int -> int * int
-
-  (** Decodes a continuation byte, returning the
-      	 *  6-bit-wide value contained within the byte. *)
-  val decode_continuation_byte : int -> int
-
-  (** Decodes a single character embedded within a string. Given a string
-      	 *  and an index into that string, returns a tuple (value, width) where:
-      	 *    value = the value of the character at the given index; and
-      	 *    width = the width of the character at the given index, in bytes.
-      	 *  Raises an appropriate error if the character is invalid. *)
-  val decode_character : string -> int -> uchar * int
-
-  (** {3 Encoding} *)
-
-  (** Encodes a header byte for the given parameters, where:
-      	 *  width = the total width of the encoded character, in bytes;
-      	 *  value = the most significant bits of the original UCS value. *)
-  val encode_header_byte : int -> uchar -> uchar	
-
-  (** Encodes a continuation byte from the given UCS
-      	 *  remainder value, returning a tuple (b, r), where:
-      	 *  b = the continuation byte;
-      	 *  r = a new UCS remainder value. *)
-  val encode_continuation_byte : uchar -> uchar * uchar
-
-  (** Encodes a single character value, returning a string containing
-      	 *  the character. Raises an error if the character value is invalid. *)
-  val encode_character : uchar -> string
+  include CHARACTER_DECODER
 end
-
-module UTF8_codec : sig
-  val width_required_for_ucs_value : uchar -> int
-  val decode_header_byte : int -> int * int
-  val decode_continuation_byte : int -> int
-  val decode_character : string -> int -> uchar * int
-
-  val encode_header_byte : int -> uchar -> uchar
-  val encode_continuation_byte : uchar -> uchar * uchar
-  val encode_character : uchar -> string
-end
-
-module XML_UTF8_codec : sig
-  val width_required_for_ucs_value : uchar -> int
-  val decode_header_byte : int -> int * int
-  val decode_continuation_byte : int -> int
-  val decode_character : string -> int -> uchar * int
-
-  val encode_header_byte : int -> uchar -> uchar
-  val encode_continuation_byte : uchar -> uchar * uchar
-  val encode_character : uchar -> string
-end
-
 (** {2 String Validators} *)
 
 (** Provides functionality for validating and processing

--- a/lib/xapi-stdext-encodings/encodings.mli
+++ b/lib/xapi-stdext-encodings/encodings.mli
@@ -25,11 +25,13 @@ exception UTF8_continuation_byte_invalid
 exception UTF8_encoding_not_canonical
 exception String_incomplete
 
+type uchar = int
+
 (** {2 UCS Validators} *)
 
 (** Validates UCS character values. *)
 module type UCS_VALIDATOR = sig
-  val validate : int32 -> unit
+  val validate : uchar -> unit
 end
 
 (** Accepts all values within the UCS character value range
@@ -41,8 +43,8 @@ module UTF8_UCS_validator : UCS_VALIDATOR
 module XML_UTF8_UCS_validator : UCS_VALIDATOR
 
 module UCS : sig
-  val min_value : int32
-  val max_value : int32
+  val min_value : uchar
+  val max_value : uchar
 
   (** Returns true if and only if the given value corresponds to a UCS
       	 *  non-character. Such non-characters are forbidden for use in open
@@ -50,30 +52,30 @@ module UCS : sig
       	 *    1. values from 0xFDD0 to 0xFDEF; and
       	 *    2. values 0xnFFFE and 0xnFFFF, where (0x0 <= n <= 0x10).
       	 *  See the Unicode 5.0 Standard, section 16.7 for further details. *)
-  val is_non_character : int32 -> bool
+  val is_non_character : uchar -> bool
 
   (** Returns true if and only if the given value lies outside the
       	 *  entire UCS range. *)
-  val is_out_of_range : int32 -> bool
+  val is_out_of_range : uchar -> bool
 
   (** Returns true if and only if the given value corresponds to a UCS
       	 *  surrogate code point, only for use in UTF-16 encoded strings.
       	 *  See the Unicode 5.0 Standard, section 16.6 for further details. *)
-  val is_surrogate : int32 -> bool
+  val is_surrogate : uchar -> bool
 end
 
-val (+++) : int32 -> int32 -> int32
-val (---) : int32 -> int32 -> int32
-val (&&&) : int32 -> int32 -> int32
-val (|||) : int32 -> int32 -> int32
-val (<<<) : int32 -> int -> int32
-val (>>>) : int32 -> int -> int32
+val (+++) : uchar -> uchar -> uchar
+val (---) : uchar -> uchar -> uchar
+val (&&&) : uchar -> uchar -> uchar
+val (|||) : uchar -> uchar -> uchar
+val (<<<) : uchar -> int -> uchar
+val (>>>) : uchar -> int -> uchar
 
 module XML : sig
   (** Returns true if and only if the given value corresponds to
       	 *  a forbidden control character as defined in section 2.2 of
       	 *  the XML specification, version 1.0. *)
-  val is_forbidden_control_character : int32 -> bool
+  val is_forbidden_control_character : uchar -> bool
 end
 
 (** {2 Character Codecs} *)
@@ -82,7 +84,7 @@ module type CHARACTER_ENCODER = sig
 
   (** Encodes a single character value, returning a string containing
       	 *  the character. Raises an error if the character value is invalid. *)
-  val encode_character : int32 -> string
+  val encode_character : uchar -> string
 
 end
 
@@ -92,13 +94,13 @@ module type CHARACTER_DECODER = sig
       	 *    value = the value of the character at the given index; and
       	 *    width = the width of the character at the given index, in bytes.
       	 *  Raises an appropriate error if the character is invalid. *)
-  val decode_character : string -> int -> int32 * int
+  val decode_character : string -> int -> uchar * int
 end
 
 module UTF8_CODEC (UCS_validator : UCS_VALIDATOR) : sig
   (** Given a valid UCS value, returns the canonical
       	 *  number of bytes required to encode the value. *)
-  val width_required_for_ucs_value : int32 -> int
+  val width_required_for_ucs_value : uchar -> int
 
   (** {3 Decoding} *)
 
@@ -116,46 +118,46 @@ module UTF8_CODEC (UCS_validator : UCS_VALIDATOR) : sig
       	 *    value = the value of the character at the given index; and
       	 *    width = the width of the character at the given index, in bytes.
       	 *  Raises an appropriate error if the character is invalid. *)
-  val decode_character : string -> int -> int32 * int
+  val decode_character : string -> int -> uchar * int
 
   (** {3 Encoding} *)
 
   (** Encodes a header byte for the given parameters, where:
       	 *  width = the total width of the encoded character, in bytes;
       	 *  value = the most significant bits of the original UCS value. *)
-  val encode_header_byte : int -> int32 -> int32	
+  val encode_header_byte : int -> uchar -> uchar	
 
   (** Encodes a continuation byte from the given UCS
       	 *  remainder value, returning a tuple (b, r), where:
       	 *  b = the continuation byte;
       	 *  r = a new UCS remainder value. *)
-  val encode_continuation_byte : int32 -> int32 * int32
+  val encode_continuation_byte : uchar -> uchar * uchar
 
   (** Encodes a single character value, returning a string containing
       	 *  the character. Raises an error if the character value is invalid. *)
-  val encode_character : int32 -> string
+  val encode_character : uchar -> string
 end
 
 module UTF8_codec : sig
-  val width_required_for_ucs_value : int32 -> int
+  val width_required_for_ucs_value : uchar -> int
   val decode_header_byte : int -> int * int
   val decode_continuation_byte : int -> int
-  val decode_character : string -> int -> int32 * int
+  val decode_character : string -> int -> uchar * int
 
-  val encode_header_byte : int -> int32 -> int32
-  val encode_continuation_byte : int32 -> int32 * int32
-  val encode_character : int32 -> string
+  val encode_header_byte : int -> uchar -> uchar
+  val encode_continuation_byte : uchar -> uchar * uchar
+  val encode_character : uchar -> string
 end
 
 module XML_UTF8_codec : sig
-  val width_required_for_ucs_value : int32 -> int
+  val width_required_for_ucs_value : uchar -> int
   val decode_header_byte : int -> int * int
   val decode_continuation_byte : int -> int
-  val decode_character : string -> int -> int32 * int
+  val decode_character : string -> int -> uchar * int
 
-  val encode_header_byte : int -> int32 -> int32
-  val encode_continuation_byte : int32 -> int32 * int32
-  val encode_character : int32 -> string
+  val encode_header_byte : int -> uchar -> uchar
+  val encode_continuation_byte : uchar -> uchar * uchar
+  val encode_character : uchar -> string
 end
 
 (** {2 String Validators} *)

--- a/lib/xapi-stdext-encodings/encodings.mli
+++ b/lib/xapi-stdext-encodings/encodings.mli
@@ -45,20 +45,6 @@ module XML : sig
   val is_forbidden_control_character : uchar -> bool
 end
 
-(** {2 Character Codecs} *)
-
-module type CHARACTER_DECODER = sig
-  (** Decodes a single character embedded within a string. Given a string
-      	 *  and an index into that string, returns a tuple (value, width) where:
-      	 *    value = the value of the character at the given index; and
-      	 *    width = the width of the character at the given index, in bytes.
-      	 *  Raises an appropriate error if the character is invalid. *)
-  val decode_character : string -> int -> uchar * int
-end
-
-module UTF8_CODEC (UCS_validator : UCS_VALIDATOR) : sig
-  include CHARACTER_DECODER
-end
 (** {2 String Validators} *)
 
 (** Provides functionality for validating and processing
@@ -76,7 +62,7 @@ module type STRING_VALIDATOR = sig
 
 end
 
-module String_validator (Decoder : CHARACTER_DECODER) : STRING_VALIDATOR
+module String_validator (Decoder : UCS_VALIDATOR) : STRING_VALIDATOR
 
 (** Represents a validation error as a tuple [(i,e)], where:
  *    [i] = the index of the first non-compliant character;

--- a/lib/xapi-stdext-encodings/test.ml
+++ b/lib/xapi-stdext-encodings/test.ml
@@ -50,7 +50,7 @@ module Logged_character_decoder (W : WIDTH_GENERATOR) = struct
       ignore (string.[index])
     done;
     indices := (index :: !indices);
-    0l, width
+    0, width
 
 end
 
@@ -63,7 +63,7 @@ module Logged_n_byte_character_decoder = Logged_character_decoder
 
 (** A decoder that succeeds for all characters. *)
 module Universal_character_decoder = struct
-  let decode_character _ _ = (0l, 1)
+  let decode_character _ _ = (0, 1)
 end
 
 (** A decoder that fails for all characters. *)
@@ -74,7 +74,7 @@ end
 (** A decoder that succeeds for all characters except the letter 'F'. *)
 module Selective_character_decoder = struct
   let decode_character string index =
-    if string.[index] = 'F' then raise Decode_error else (0l, 1)
+    if string.[index] = 'F' then raise Decode_error else (0, 1)
 end
 
 (* === Mock codecs ========================================================= *)
@@ -207,9 +207,9 @@ module UCS = struct include E.UCS
       b. non-characters at the end of the basic multilingual plane;
       c. non-characters at the end of the private use area. *)
   let non_characters = [
-    0x00fdd0l; 0x00fdefl; (* case a. *)
-    0x00fffel; 0x00ffffl; (* case b. *)
-    0x1ffffel; 0x1fffffl; (* case c. *)
+    0x00fdd0; 0x00fdef; (* case a. *)
+    0x00fffe; 0x00ffff; (* case b. *)
+    0x1ffffe; 0x1fffff; (* case c. *)
   ]
 
   (** A list of UCS character values located immediately before or
@@ -218,9 +218,9 @@ module UCS = struct include E.UCS
       b. non-characters at the end of the basic multilingual plane;
       c. non-characters at the end of the private use area. *)
   let valid_characters_next_to_non_characters = [
-    0x00fdcfl; 0x00fdf0l; (* case a. *)
-    0x00fffdl; 0x010000l; (* case b. *)
-    0x1ffffdl; 0x200000l; (* case c. *)
+    0x00fdcf; 0x00fdf0; (* case a. *)
+    0x00fffd; 0x010000; (* case b. *)
+    0x1ffffd; 0x200000; (* case c. *)
   ]
 
   let test_is_non_character () =
@@ -230,16 +230,16 @@ module UCS = struct include E.UCS
           valid_characters_next_to_non_characters
 
   let test_is_out_of_range () =
-        assert_true  (is_out_of_range (min_value --- 1l));
+        assert_true  (is_out_of_range (min_value --- 1));
         assert_false (is_out_of_range (min_value));
         assert_false (is_out_of_range (max_value));
-        assert_true  (is_out_of_range (max_value +++ 1l))
+        assert_true  (is_out_of_range (max_value +++ 1))
 
   let test_is_surrogate () =
-        assert_false (is_surrogate (0xd7ffl));
-        assert_true  (is_surrogate (0xd800l));
-        assert_true  (is_surrogate (0xdfffl));
-        assert_false (is_surrogate (0xe000l))
+        assert_false (is_surrogate (0xd7ff));
+        assert_true  (is_surrogate (0xd800));
+        assert_true  (is_surrogate (0xdfff));
+        assert_false (is_surrogate (0xe000))
 
   let tests =
     [ "test_is_non_character", `Quick, test_is_non_character
@@ -252,12 +252,12 @@ end
 module XML = struct include E.XML
 
   let test_is_forbidden_control_character () =
-        assert_true  (is_forbidden_control_character (0x00l));
-        assert_true  (is_forbidden_control_character (0x19l));
-        assert_false (is_forbidden_control_character (0x09l));
-        assert_false (is_forbidden_control_character (0x0al));
-        assert_false (is_forbidden_control_character (0x0dl));
-        assert_false (is_forbidden_control_character (0x20l))
+        assert_true  (is_forbidden_control_character (0x00));
+        assert_true  (is_forbidden_control_character (0x19));
+        assert_false (is_forbidden_control_character (0x09));
+        assert_false (is_forbidden_control_character (0x0a));
+        assert_false (is_forbidden_control_character (0x0d));
+        assert_false (is_forbidden_control_character (0x20))
 
   let tests =
       [ "test_is_forbidden_control_character", `Quick, test_is_forbidden_control_character
@@ -268,8 +268,8 @@ end
 module UTF8_UCS_validator = struct include E.UTF8_UCS_validator
 
   let test_validate () =
-        let value = ref (UCS.min_value --- 1l) in
-        while !value <= (UCS.max_value +++ 1l) do
+        let value = ref (UCS.min_value --- 1) in
+        while !value <= (UCS.max_value +++ 1) do
           if UCS.is_out_of_range !value
           then Alcotest.check_raises "should fail"
               E.UCS_value_out_of_range
@@ -282,7 +282,7 @@ module UTF8_UCS_validator = struct include E.UTF8_UCS_validator
               (fun () -> validate !value)
           else
             validate !value;
-          value := !value +++ 1l
+          value := !value +++ 1
         done
 
   let tests =
@@ -295,8 +295,8 @@ end
 module XML_UTF8_UCS_validator = struct include E.XML_UTF8_UCS_validator
 
   let test_validate () =
-        let value = ref (UCS.min_value --- 1l) in
-        while !value <= (UCS.max_value +++ 1l) do
+        let value = ref (UCS.min_value --- 1) in
+        while !value <= (UCS.max_value +++ 1) do
           if UCS.is_out_of_range !value
           then Alcotest.check_raises "should fail" E.UCS_value_out_of_range
               (fun () -> validate !value)
@@ -311,7 +311,7 @@ module XML_UTF8_UCS_validator = struct include E.XML_UTF8_UCS_validator
               (fun () -> validate !value)
           else
             validate !value;
-          value := !value +++ 1l
+          value := !value +++ 1
         done
 
   let tests =
@@ -328,10 +328,10 @@ module UTF8_codec = struct include E.UTF8_codec
       w = the width of the encoded character, in bytes. *)
   let valid_ucs_value_widths =
     [
-      (1l       , 1); ((1l <<<  7) --- 1l, 1);
-      (1l <<<  7, 2); ((1l <<< 11) --- 1l, 2);
-      (1l <<< 11, 3); ((1l <<< 16) --- 1l, 3);
-      (1l <<< 16, 4); ((1l <<< 21) --- 1l, 4);
+      (1       , 1); ((1 <<<  7) --- 1, 1);
+      (1 <<<  7, 2); ((1 <<< 11) --- 1, 2);
+      (1 <<< 11, 3); ((1 <<< 16) --- 1, 3);
+      (1 <<< 16, 4); ((1 <<< 21) --- 1, 4);
     ]
 
   let test_width_required_for_ucs_value () =
@@ -436,26 +436,27 @@ module UTF8_codec = struct include E.UTF8_codec
   let valid_character_decodings = [
     (*               7654321   *)
     (* 0b0xxxxxxx                                  *)  (* 00000000000000xxxxxxx   *)
-    "\x00"             (* 0b00000000                                  *), (0b000000000000000000000l, 1);
-    "\x7f"             (* 0b01111111                                  *), (0b000000000000001111111l, 1);
+    "\x00"             (* 0b00000000                                  *), (0b000000000000000000000, 1);
+    "\x7f"             (* 0b01111111                                  *), (0b000000000000001111111, 1);
     (*           10987654321   *)
     (* 0b110xxxsx 0b10xxxxxx                       *)  (* 0000000000xxxsxxxxxxx   *)
-    "\xc2\x80"         (* 0b11000010 0b10000000                       *), (0b000000000000010000000l, 2);
-    "\xdf\xbf"         (* 0b11011111 0b10111111                       *), (0b000000000011111111111l, 2);
+    "\xc2\x80"         (* 0b11000010 0b10000000                       *), (0b000000000000010000000, 2);
+    "\xdf\xbf"         (* 0b11011111 0b10111111                       *), (0b000000000011111111111, 2);
     (*      6543210987654321   *)
     (* 0b1110xxxx 0b10sxxxxx 0b10xxxxxx            *)  (*      xxxxsxxxxxxxxxxx   *)
-    "\xe0\xa0\x80"     (* 0b11100000 0b10100000 0b10000000            *), (0b000000000100000000000l, 3);
-    "\xef\xbf\xbf"     (* 0b11101111 0b10111111 0b10111111            *), (0b000001111111111111111l, 3);
+    "\xe0\xa0\x80"     (* 0b11100000 0b10100000 0b10000000            *), (0b000000000100000000000, 3);
+    "\xef\xbf\xbf"     (* 0b11101111 0b10111111 0b10111111            *), (0b000001111111111111111, 3);
     (* 109876543210987654321   *)
     (* 0b11110xxx 0b10xsxxxx 0b10xxxxxx 0b10xxxxxx *)  (* xxxxsxxxxxxxxxxxxxxxx   *)
-    "\xf0\x90\x80\x80" (* 0b11110000 0b10010000 0b10000000 0b10000000 *), (0b000010000000000000000l, 4);
-    "\xf7\xbf\xbf\xbf" (* 0b11110111 0b10111111 0b10111111 0b10111111 *), (0b111111111111111111111l, 4);
+    "\xf0\x90\x80\x80" (* 0b11110000 0b10010000 0b10000000 0b10000000 *), (0b000010000000000000000, 4);
+    "\xf7\xbf\xbf\xbf" (* 0b11110111 0b10111111 0b10111111 0b10111111 *), (0b111111111111111111111, 4);
   ]
 
+  let uchar = Alcotest.int
   let test_decode_character_when_valid () =
         List.iter
           (fun (string, (value, width)) ->
-             Alcotest.(check (pair int32 int)) "same pair"
+             Alcotest.(check (pair uchar int)) "same pair"
                (Lenient_UTF8_codec.decode_character string 0)
                (value, width))
           valid_character_decodings
@@ -488,7 +489,7 @@ module UTF8_codec = struct include E.UTF8_codec
     let width = E.UTF8_codec.width_required_for_ucs_value value in
     if (value <> decoded_value) then Alcotest.fail
         (Printf.sprintf
-           "expected value %06lx but decoded value %06lx\n"
+           "expected value %06x but decoded value %06x\n"
            value decoded_value);
     if (width <> decoded_width) then Alcotest.fail
         (Printf.sprintf
@@ -499,7 +500,7 @@ module UTF8_codec = struct include E.UTF8_codec
         let value = ref UCS.min_value in
         while !value <= UCS.max_value do
           test_encode_decode_cycle_for_value !value;
-          value := Int32.add !value 1l;
+          value := Int.add !value 1;
         done
 
   let tests =


### PR DESCRIPTION
Further optimization are possible, but this removes allocations from the validation code.

Further optimization examples:
* using an automate built either using 'Re' os just good old 'ocamllex' / 'ulex')
* adding a fastpath when the string is all ascii in the valid range (no UTF8 processing needed, and we could optimistically process it with that first, and fall back to unicode processing if it fails)
* removing the functor (it prevents inlining, at least without flambda). If this was a regular function (taking another function as argument) then inlining might've worked better

The commits here drop code and refactor the internals step by step while keeping the remaining relevant tests working.

This is a breaking change: it removes modules from the interface and changes the type of some functions. However in practice XAPI is the only user, and the module type of the string validator doesn't change, so XAPI doesn't require any updates to take advantage of this code.