### PR TITLE
CA-382014: Fix blkgetsize return type mismatch

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -44,6 +44,9 @@
     ocaml
     (alcotest (and (>= 0.6.0) :with-test))
     (odoc :with-doc)
+    (bechamel :with-test)
+    (bechamel-notty :with-test)
+    (notty :with-test)
   )
 )
 

--- a/lib/xapi-stdext-unix/blkgetsize.h
+++ b/lib/xapi-stdext-unix/blkgetsize.h
@@ -1,0 +1,6 @@
+#ifndef BLKGETSIZE_H
+#define BLKGETSIZE_H
+
+#include <stdint.h>
+int stdext_blkgetsize(int fd, uint64_t *psize);
+#endif

--- a/lib/xapi-stdext-unix/blkgetsize_stubs.c
+++ b/lib/xapi-stdext-unix/blkgetsize_stubs.c
@@ -30,6 +30,7 @@
 #include <caml/callback.h>
 #include <caml/bigarray.h>
 
+#include "blkgetsize.h"
 #ifdef __linux__
 #include <linux/fs.h>
 

--- a/lib/xapi-stdext-unix/unixext_stubs.c
+++ b/lib/xapi-stdext-unix/unixext_stubs.c
@@ -126,7 +126,7 @@ CAMLprim value stub_unixext_set_sock_keepalives(value fd, value count, value idl
 
 void unixext_error(int code)
 {
-	static value *exn = NULL;
+	static const value *exn = NULL;
 
 	if (!exn) {
 		exn = caml_named_value("unixext.unix_error");

--- a/lib/xapi-stdext-unix/unixext_stubs.c
+++ b/lib/xapi-stdext-unix/unixext_stubs.c
@@ -36,6 +36,8 @@
 #include <caml/unixsupport.h>
 #include <caml/threads.h>
 
+#include "blkgetsize.h"
+
 /* Set the TCP_NODELAY flag on a Unix.file_descr */
 CAMLprim value stub_unixext_set_tcp_nodelay (value fd, value bool)
 {
@@ -61,7 +63,6 @@ CAMLprim value stub_unixext_fsync (value fd)
 	CAMLreturn(Val_unit);
 }
 	
-extern uint64_t stdext_blkgetsize(int fd, uint64_t *psize);
 
 CAMLprim value stub_unixext_blkgetsize64(value fd)
 {

--- a/xapi-stdext-encodings.opam
+++ b/xapi-stdext-encodings.opam
@@ -10,10 +10,10 @@ depends: [
   "dune" {>= "2.7"}
   "ocaml"
   "alcotest" {>= "0.6.0" & with-test}
-  "bechamel" { with-test}
-  "bechamel-notty" { with-test}
-  "notty" { with-test}
   "odoc" {with-doc}
+  "bechamel" {with-test}
+  "bechamel-notty" {with-test}
+  "notty" {with-test}
 ]
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
Found by an LTO enabled build
<img width="1896" alt="Screenshot 2023-08-23 at 14 35 25" src="https://github.com/xapi-project/stdext/assets/721894/2f1f39b8-98e5-457d-af66-88f001e1d390">
