### PR TITLE
Backport CA-382014 - type mismatch in stubs

### DIFF
--- a/lib/xapi-stdext-unix/blkgetsize.h
+++ b/lib/xapi-stdext-unix/blkgetsize.h
@@ -1,0 +1,6 @@
+#ifndef BLKGETSIZE_H
+#define BLKGETSIZE_H
+
+#include <stdint.h>
+int stdext_blkgetsize(int fd, uint64_t *psize);
+#endif

--- a/lib/xapi-stdext-unix/blkgetsize_stubs.c
+++ b/lib/xapi-stdext-unix/blkgetsize_stubs.c
@@ -30,6 +30,7 @@
 #include <caml/callback.h>
 #include <caml/bigarray.h>
 
+#include "blkgetsize.h"
 #ifdef __linux__
 #include <linux/fs.h>
 

--- a/lib/xapi-stdext-unix/unixext_stubs.c
+++ b/lib/xapi-stdext-unix/unixext_stubs.c
@@ -183,7 +183,7 @@ CAMLprim value stub_fdset_is_set_and_clear(value set, value fd)
 
 void unixext_error(int code)
 {
-	static value *exn = NULL;
+	static const value *exn = NULL;
 
 	if (!exn) {
 		exn = caml_named_value("unixext.unix_error");

--- a/lib/xapi-stdext-unix/unixext_stubs.c
+++ b/lib/xapi-stdext-unix/unixext_stubs.c
@@ -36,6 +36,8 @@
 #include <caml/unixsupport.h>
 #include <caml/threads.h>
 
+#include "blkgetsize.h"
+
 /* Set the TCP_NODELAY flag on a Unix.file_descr */
 CAMLprim value stub_unixext_set_tcp_nodelay (value fd, value bool)
 {
@@ -61,7 +63,6 @@ CAMLprim value stub_unixext_fsync (value fd)
 	CAMLreturn(Val_unit);
 }
 	
-extern uint64_t stdext_blkgetsize(int fd, uint64_t *psize);
 
 CAMLprim value stub_unixext_blkgetsize64(value fd)
 {


### PR DESCRIPTION
* unixext_stubs: fix const warning
* CA-382014: blkgetsize: fix return type mismatch

This code is distributed as part of https://github.com/xapi-project/xs-opam/.