### PR TITLE
[maintenance]: fix dune-project

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -41,7 +41,7 @@
   (name xapi-stdext-encodings)
   (synopsis "Xapi's standard library extension, Encodings")
   (depends
-    (ocaml (>= 4.13))
+    (ocaml (>= 4.13.0))
     (alcotest (and (>= 0.6.0) :with-test))
     (odoc :with-doc)
     (bechamel :with-test)
@@ -65,7 +65,7 @@
   (name xapi-stdext-std)
   (synopsis "Xapi's standard library extension, Stdlib")
   (depends
-    (ocaml (>= 4.08))
+    (ocaml (>= 4.08.0))
     (alcotest :with-test)
     (odoc :with-doc)
   )
@@ -87,7 +87,7 @@
   (name xapi-stdext-unix)
   (synopsis "Xapi's standard library extension, Unix")
   (depends
-    (ocaml (>= 4.12))
+    (ocaml (>= 4.12.0))
     base-unix
     (fd-send-recv (>= 2.0.0))
     (odoc :with-doc)

--- a/xapi-stdext-encodings.opam
+++ b/xapi-stdext-encodings.opam
@@ -15,7 +15,6 @@ depends: [
   "bechamel-notty" {with-test}
   "notty" {with-test}
 ]
-available: arch != "arm32" & arch != "x86_32"
 build: [
   ["dune" "subst"] {dev}
   [
@@ -31,3 +30,4 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/xapi-project/stdext.git"
+available: arch != "arm32" & arch != "x86_32"

--- a/xapi-stdext-encodings.opam.template
+++ b/xapi-stdext-encodings.opam.template
@@ -1,0 +1,1 @@
+available: arch != "arm32" & arch != "x86_32"

--- a/xapi-stdext-unix-opam.template
+++ b/xapi-stdext-unix-opam.template
@@ -1,0 +1,2 @@
+depexts: ["linux-headers"] {os-distribution = "alpine"}
+available: [ os = "macos" | os = "linux" ]

--- a/xapi-stdext-unix.opam
+++ b/xapi-stdext-unix.opam
@@ -14,8 +14,6 @@ depends: [
   "odoc" {with-doc}
   "xapi-stdext-pervasives" {= version}
 ]
-depexts: ["linux-headers"] {os-distribution = "alpine"}
-available: [ os = "macos" | os = "linux" ]
 build: [
   ["dune" "subst"] {dev}
   [
@@ -31,3 +29,5 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/xapi-project/stdext.git"
+depexts: ["linux-headers"] {os-distribution = "alpine"}
+available: [ os = "macos" | os = "linux" ]

--- a/xapi-stdext-unix.opam.template
+++ b/xapi-stdext-unix.opam.template
@@ -1,0 +1,2 @@
+depexts: ["linux-headers"] {os-distribution = "alpine"}
+available: [ os = "macos" | os = "linux" ]


### PR DESCRIPTION
The opam files were hand edited, but they are generated from 'dune-project', so running 'dune build' would undo any changes.

Fixes https://github.com/xapi-project/stdext/issues/78 Fixes: 42f237c ("opam: update metadata")

No functional change.