### PR TITLE
xapi-stdext-std: add Listext.List.find_minimum

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+## Unreleased
+- std: add Listext.List.find_minimum
+
 ## v4.23.0 (30-Oct-2023)
 - unix: fix blkgetsize return type mismatch (CA-382014)
 - unix: add function to recursively remove files

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
-## Unreleased
+## v4.24.0 (17-Jan-2024)
+- unix: really_read now retries reads on EINTR
 - std: add Listext.List.find_minimum
 
 ## v4.23.0 (30-Oct-2023)

--- a/lib/xapi-stdext-encodings/encodings.ml
+++ b/lib/xapi-stdext-encodings/encodings.ml
@@ -34,15 +34,15 @@ module UCS = struct
     false
     || (0xfdd0 <= value && value <= 0xfdef) (* case 1 *)
     || Int.logand 0xfffe value = 0xfffe
-    (* case 2 *)
-    [@@inline]
+  (* case 2 *)
+  [@@inline]
 end
 
 module XML = struct
   let is_illegal_control_character value =
     let value = Uchar.to_int value in
     value < 0x20 && value <> 0x09 && value <> 0x0a && value <> 0x0d
-    [@@inline]
+  [@@inline]
 end
 
 (* === UCS Validators === *)
@@ -55,7 +55,7 @@ module UTF8_UCS_validator = struct
   let validate value =
     if (UCS.is_non_character [@inlined]) (Uchar.to_int value) then
       raise UCS_value_prohibited_in_UTF8
-    [@@inline]
+  [@@inline]
 end
 
 module XML_UTF8_UCS_validator = struct

--- a/lib/xapi-stdext-std/listext.ml
+++ b/lib/xapi-stdext-std/listext.ml
@@ -196,4 +196,8 @@ module List = struct
         aux ((upper - 1) :: accu) (upper - 1)
     in
     aux []
+
+  let find_minimum compare =
+    let min a b = if compare a b <= 0 then a else b in
+    function [] -> None | x :: xs -> Some (List.fold_left min x xs)
 end

--- a/lib/xapi-stdext-std/listext.mli
+++ b/lib/xapi-stdext-std/listext.mli
@@ -49,6 +49,13 @@ module List : sig
   val iteri_right : (int -> 'a -> unit) -> 'a list -> unit
   (** [iteri_right f l] is {!Stdlib.List.iteri}[ f (]{!Stdlib.List.rev}[ l)] *)
 
+  (** {1 List searching} *)
+
+  val find_minimum : ('a -> 'a -> int) -> 'a list -> 'a option
+  (** [find_minimum cmp l] returns the lowest element in [l] according to
+      the sort order of [cmp], or [None] if the list is empty. When two ore
+      more elements match the lowest value, the left-most is returned. *)
+
   (** {1 Using indices to manipulate lists} *)
 
   val chop : int -> 'a list -> 'a list * 'a list

--- a/lib/xapi-stdext-std/xstringext.ml
+++ b/lib/xapi-stdext-std/xstringext.ml
@@ -74,8 +74,8 @@ module String = struct
         let aux h t =
           ( if List.mem_assoc h rules then
               List.assoc h rules
-          else
-            of_char h
+            else
+              of_char h
           )
           :: t
         in


### PR DESCRIPTION
Useful to get the lowest or highest element in a list in linear time, as it avoid sorting the whole list.